### PR TITLE
Correct model used by schema builder

### DIFF
--- a/api/api/tasks/chat_task_schema_generation/schema_generation_agent.py
+++ b/api/api/tasks/chat_task_schema_generation/schema_generation_agent.py
@@ -42,7 +42,7 @@ class SchemaBuilderOutput(BaseModel):
 
 
 # TODO: switch back to Claude 3.7 when we'll have more token quotas
-@workflowai.agent(id="agent-schema-generation", model=workflowai.Model.CLAUDE_3_5_HAIKU_20241022)
+@workflowai.agent(id="agent-schema-generation", model=workflowai.Model.CLAUDE_3_5_SONNET_20241022)
 async def run_agent_schema_generation(
     input: SchemaBuilderInput,
 ) -> SchemaBuilderOutput:


### PR DESCRIPTION
Closes [WOR-4112: Validation errors triggered by the schema builder](https://linear.app/workflowai/issue/WOR-4112/validation-errors-triggered-by-the-schema-builder)

@guillaq there was a "typo" in my model picking for [WOR-4068: features/schemas triggers rate limits errors (Claude 3.7S)](https://linear.app/workflowai/issue/WOR-4068/featuresschemas-triggers-rate-limits-errors-claude-37s)

