### PR TITLE
Fix Slack notif content for meta agent

### DIFF
--- a/api/api/services/internal_tasks/meta_agent_service.py
+++ b/api/api/services/internal_tasks/meta_agent_service.py
@@ -491,11 +491,17 @@ class MetaAgentService:
         ), agent_runs
 
     def dispatch_new_user_messages_event(self, messages: list[MetaAgentChatMessage]):
-        # Extract the last message from the list since the latest "ASSISTANT" message
-        latest_user_messages = [message for message in reversed(messages) if message.role == "USER"]
+        # Get all consecutive USER messages at the end of the conversation
+        latest_user_messages: list[MetaAgentChatMessage] = []
+        for message in reversed(messages):
+            if message.role == "USER":
+                latest_user_messages.insert(0, message)
+            else:
+                break
+
         if latest_user_messages:
             self.event_router(
-                MetaAgentChatMessagesSent(messages=[message.to_domain() for message in reversed(latest_user_messages)]),
+                MetaAgentChatMessagesSent(messages=[message.to_domain() for message in latest_user_messages]),
             )
         else:
             self._logger.warning("No user message found in the list of messages")

--- a/api/api/services/internal_tasks/meta_agent_service_test.py
+++ b/api/api/services/internal_tasks/meta_agent_service_test.py
@@ -397,6 +397,7 @@ class TestMetaAgentService:
         [
             (
                 [
+                    MetaAgentChatMessage(role="USER", content="User0"),
                     MetaAgentChatMessage(role="ASSISTANT", content="A"),
                     MetaAgentChatMessage(role="USER", content="User1"),
                     MetaAgentChatMessage(role="USER", content="User2"),


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4113/duplicate-message-for-the-meta-agent-in-customer-journey