### PR TITLE
[WOR-4122] Schemas Preview is called without schema $defs

### DIFF
--- a/client/src/components/NewTaskModal/NewTaskModal.tsx
+++ b/client/src/components/NewTaskModal/NewTaskModal.tsx
@@ -203,22 +203,22 @@ export function NewTaskModal() {
 
   const computedInputSchema = useMemo(() => {
     if (!inputSplattedSchema) return undefined;
-    const { schema, definitions } = fromSplattedEditorFieldsToSchema(inputSplattedSchema);
+    const { schema, definitions } = fromSplattedEditorFieldsToSchema(inputSplattedSchema, inputSchema?.$defs);
 
     return {
       ...schema,
       $defs: definitions,
     };
-  }, [inputSplattedSchema]);
+  }, [inputSplattedSchema, inputSchema?.$defs]);
 
   const computedOutputSchema = useMemo(() => {
     if (!outputSplattedSchema) return undefined;
-    const { schema, definitions } = fromSplattedEditorFieldsToSchema(outputSplattedSchema);
+    const { schema, definitions } = fromSplattedEditorFieldsToSchema(outputSplattedSchema, outputSchema?.$defs);
     return {
       ...schema,
       $defs: definitions,
     };
-  }, [outputSplattedSchema]);
+  }, [outputSplattedSchema, outputSchema?.$defs]);
 
   const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4122/schemaspreview-is-called-without-schema-dollardefs

@yannbu 
As discussed during our call we are sending it when it's defs that we are getting from chat.
It's probably a good idea to assign to you to QA, you know already what is happening and stuff.
@anyacherniss OK with you for @yannbu to QA?

Demo:
<img width="1041" alt="Screenshot 2025-03-31 at 12 14 17 PM" src="https://github.com/user-attachments/assets/71eb2903-f71b-40d5-a490-cc9d8659d442" />
<img width="1146" alt="Screenshot 2025-03-31 at 12 12 45 PM" src="https://github.com/user-attachments/assets/704b2b68-dd4b-4291-924e-2723f2b587df" />
