### PR TITLE
handle missing defs in agent preview generation.

### DIFF
--- a/api/api/services/internal_tasks/internal_tasks_service.py
+++ b/api/api/services/internal_tasks/internal_tasks_service.py
@@ -119,7 +119,7 @@ from core.tasks.task_input_example.task_input_migration_task import (
     stream_task_input_migration_task,
 )
 from core.tools import ToolKind
-from core.utils.schema_sanitation import add_missing_defs, streamline_schema
+from core.utils.schema_sanitation import streamline_schema
 from core.utils.schemas import EXPLAINATION_KEY, schema_needs_explanation, strip_json_schema_metadata_keys
 from core.utils.url_utils import extract_and_fetch_urls
 
@@ -1139,7 +1139,7 @@ class InternalTasksService:
         try:
             # In some cases, $defs are missing from the schema sent by the frontend.
             # Ex: when the user manually added a "document" field to the schema.
-            add_missing_defs(schema)
+            schema = streamline_schema(schema)
 
             agent_io = SerializableTaskIO(
                 json_schema=schema,

--- a/api/api/services/internal_tasks/internal_tasks_service.py
+++ b/api/api/services/internal_tasks/internal_tasks_service.py
@@ -119,7 +119,7 @@ from core.tasks.task_input_example.task_input_migration_task import (
     stream_task_input_migration_task,
 )
 from core.tools import ToolKind
-from core.utils.schema_sanitation import streamline_schema
+from core.utils.schema_sanitation import _add_missing_defs, streamline_schema
 from core.utils.schemas import EXPLAINATION_KEY, schema_needs_explanation, strip_json_schema_metadata_keys
 from core.utils.url_utils import extract_and_fetch_urls
 
@@ -1103,38 +1103,50 @@ class InternalTasksService:
         self,
         task_input: GenerateTaskPreviewTaskInput,
     ) -> AsyncIterator[GenerateTaskPreviewTaskOutput]:
-        if task_input.current_preview:
-            self._feed_input_validation_error(task_input)
-            self._feed_output_validation_error(task_input)
-
+        self._feed_input_validation_error(task_input)
+        self._feed_output_validation_error(task_input)
         return stream_generate_task_preview(task_input)
 
     def _feed_input_validation_error(self, task_input: GenerateTaskPreviewTaskInput) -> None:
         if task_input.current_preview is None:
             return
 
-        try:
-            agent_input = SerializableTaskIO(
-                json_schema=task_input.task_input_schema,
-                version="1",
-            )
-            agent_input.enforce(task_input.current_preview.input)
-        except JSONSchemaValidationError as e:
-            task_input.current_preview_input_validation_error = str(e)
-        except Exception as e:
-            self.logger.exception("Unexpected error while validating current preview input", exc_info=e)
+        self._validate_preview_field(
+            task_input,
+            schema=task_input.task_input_schema,
+            value=task_input.current_preview.input,
+            error_attr="current_preview_input_validation_error",
+        )
 
     def _feed_output_validation_error(self, task_input: GenerateTaskPreviewTaskInput) -> None:
         if task_input.current_preview is None:
             return
 
+        self._validate_preview_field(
+            task_input,
+            schema=task_input.task_output_schema,
+            value=task_input.current_preview.output,
+            error_attr="current_preview_output_validation_error",
+        )
+
+    def _validate_preview_field(
+        self,
+        task_input: GenerateTaskPreviewTaskInput,
+        schema: dict[str, Any],
+        value: dict[str, Any],
+        error_attr: str,
+    ) -> None:
         try:
-            agent_output = SerializableTaskIO(
-                json_schema=task_input.task_output_schema,
+            # In some cases, $defs are missing from the schema sent by the frontend.
+            # Ex: when the user manually added a "document" field to the schema.
+            _add_missing_defs(schema)
+
+            agent_io = SerializableTaskIO(
+                json_schema=schema,
                 version="1",
             )
-            agent_output.enforce(task_input.current_preview.output)
+            agent_io.enforce(value)
         except JSONSchemaValidationError as e:
-            task_input.current_preview_output_validation_error = str(e)
+            setattr(task_input, error_attr, str(e))
         except Exception as e:
-            self.logger.exception("Unexpected error while validating current preview output", exc_info=e)
+            self.logger.exception("Unexpected error while validating current preview", exc_info=e)

--- a/api/api/services/internal_tasks/internal_tasks_service.py
+++ b/api/api/services/internal_tasks/internal_tasks_service.py
@@ -119,7 +119,7 @@ from core.tasks.task_input_example.task_input_migration_task import (
     stream_task_input_migration_task,
 )
 from core.tools import ToolKind
-from core.utils.schema_sanitation import _add_missing_defs, streamline_schema
+from core.utils.schema_sanitation import add_missing_defs, streamline_schema
 from core.utils.schemas import EXPLAINATION_KEY, schema_needs_explanation, strip_json_schema_metadata_keys
 from core.utils.url_utils import extract_and_fetch_urls
 
@@ -1139,7 +1139,7 @@ class InternalTasksService:
         try:
             # In some cases, $defs are missing from the schema sent by the frontend.
             # Ex: when the user manually added a "document" field to the schema.
-            _add_missing_defs(schema)
+            add_missing_defs(schema)
 
             agent_io = SerializableTaskIO(
                 json_schema=schema,

--- a/api/api/services/internal_tasks/internal_tasks_service_test.py
+++ b/api/api/services/internal_tasks/internal_tasks_service_test.py
@@ -1913,5 +1913,4 @@ class TestFeedValidationError:
         internal_tasks_service._feed_output_validation_error(agent_input)  # pyright: ignore[reportPrivateUsage]
 
         # Assert
-        assert "File" in agent_input.task_output_schema["$defs"]
         assert agent_input.current_preview_output_validation_error is None

--- a/api/api/services/internal_tasks/internal_tasks_service_test.py
+++ b/api/api/services/internal_tasks/internal_tasks_service_test.py
@@ -1753,15 +1753,165 @@ class TestStreamGenerateTaskPreview:
                 mock_stream_generate_task_preview.assert_called_once()
 
 
-class TestGetAvailableToolDescriptions:
-    def test_get_available_tool_descriptions(
+class TestFeedValidationError:
+    @pytest.fixture
+    def task_input(self):
+        return GenerateTaskPreviewTaskInput(
+            chat_messages=[UserChatMessage(content="test")],
+            task_input_schema={"type": "object", "properties": {"name": {"type": "string"}}},
+            task_output_schema={"type": "object", "properties": {"result": {"type": "string"}}},
+            current_preview=TaskPreview(
+                input={"name": "test input"},
+                output={"result": "test output"},
+            ),
+        )
+
+    def test_feed_input_validation_error_no_preview(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        task_input.current_preview = None
+
+        # Act
+        internal_tasks_service._feed_input_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_input_validation_error is None
+
+    def test_feed_output_validation_error_no_preview(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        task_input.current_preview = None
+
+        # Act
+        internal_tasks_service._feed_output_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_output_validation_error is None
+
+    def test_feed_input_validation_error_valid_input(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Act
+        internal_tasks_service._feed_input_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_input_validation_error is None
+
+    def test_feed_output_validation_error_valid_output(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Act
+        internal_tasks_service._feed_output_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_output_validation_error is None
+
+    def test_feed_input_validation_error_invalid_input(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        assert task_input.current_preview is not None
+        task_input.current_preview.input = {"name": 3}
+
+        # Act
+        internal_tasks_service._feed_input_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_input_validation_error is not None
+        assert " 3 is not of type 'string'" in task_input.current_preview_input_validation_error
+
+    def test_feed_output_validation_error_invalid_output(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        assert task_input.current_preview is not None
+        task_input.current_preview.output = {"result": True}
+
+        # Act
+        internal_tasks_service._feed_output_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+        # Assert
+        assert task_input.current_preview_output_validation_error is not None
+        assert "True is not of type 'string'" in task_input.current_preview_output_validation_error
+
+    def test_feed_input_validation_error_unexpected_exception(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        unexpected_error = ValueError("Unexpected validation error")
+
+        # Act
+        with patch(
+            "core.domain.task_io.SerializableTaskIO.enforce",
+            side_effect=unexpected_error,
+        ):
+            with patch.object(internal_tasks_service.logger, "exception") as mock_logger:
+                internal_tasks_service._feed_input_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+                # Assert
+                assert task_input.current_preview_input_validation_error is None
+                mock_logger.assert_called_once()
+
+    def test_feed_output_validation_error_unexpected_exception(
+        self,
+        internal_tasks_service: InternalTasksService,
+        task_input: GenerateTaskPreviewTaskInput,
+    ):
+        # Arrange
+        unexpected_error = ValueError("Unexpected validation error")
+
+        # Act
+        with patch(
+            "core.domain.task_io.SerializableTaskIO.enforce",
+            side_effect=unexpected_error,
+        ):
+            with patch.object(internal_tasks_service.logger, "exception") as mock_logger:
+                internal_tasks_service._feed_output_validation_error(task_input)  # pyright: ignore[reportPrivateUsage]
+
+                # Assert
+                assert task_input.current_preview_output_validation_error is None
+                mock_logger.assert_called_once()
+
+    def test_feed_input_validation_error_referencing_error(
         self,
         internal_tasks_service: InternalTasksService,
     ):
+        schema_with_missing_defs = {
+            "type": "object",
+            "properties": {
+                "result": {"$ref": "#/$defs/File"},  # ref is present but defs is missing
+            },
+        }
+
+        agent_input = GenerateTaskPreviewTaskInput(
+            chat_messages=[UserChatMessage(content="test")],
+            task_input_schema=schema_with_missing_defs,
+            task_output_schema=schema_with_missing_defs,
+            current_preview=TaskPreview(
+                input={"name": {}},
+                output={"result": {}},
+            ),
+        )
+
         # Act
-        result = internal_tasks_service._get_available_tool_descriptions()  # pyright: ignore[reportPrivateUsage]
+        internal_tasks_service._feed_output_validation_error(agent_input)  # pyright: ignore[reportPrivateUsage]
 
         # Assert
-        assert len(result) == 2
-        assert result[0].handle == ToolKind.WEB_SEARCH_PERPLEXITY_SONAR_PRO.value
-        assert result[1].handle == ToolKind.WEB_BROWSER_TEXT.value
+        assert "File" in agent_input.task_output_schema["$defs"]
+        assert agent_input.current_preview_output_validation_error is None

--- a/api/core/utils/schema_sanitation.py
+++ b/api/core/utils/schema_sanitation.py
@@ -113,7 +113,7 @@ class _NoTitleJsonSchemaGenerator(GenerateJsonSchema):
         return generated
 
 
-def _add_missing_defs(schema: dict[str, Any]) -> dict[str, Any]:
+def add_missing_defs(schema: dict[str, Any]) -> dict[str, Any]:
     schema_defs = _build_internal_defs(streamline=False)
 
     refs: set[str] = set()
@@ -149,7 +149,7 @@ def _normalize_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     # The cleanup is lighter than sanitation to avoid overriding user preferences
     _check_for_protected_keys(schema)
 
-    schema = _add_missing_defs(schema)
+    schema = add_missing_defs(schema)
     schema = _remove_empty_defs(schema)
     schema, _ = fix_non_object_root(schema)
 

--- a/api/core/utils/schema_sanitation.py
+++ b/api/core/utils/schema_sanitation.py
@@ -113,7 +113,8 @@ class _NoTitleJsonSchemaGenerator(GenerateJsonSchema):
         return generated
 
 
-def add_missing_defs(schema: dict[str, Any]) -> dict[str, Any]:
+@deprecated("Use streamline_schema instead")
+def _add_missing_defs(schema: dict[str, Any]) -> dict[str, Any]:
     schema_defs = _build_internal_defs(streamline=False)
 
     refs: set[str] = set()
@@ -149,7 +150,7 @@ def _normalize_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     # The cleanup is lighter than sanitation to avoid overriding user preferences
     _check_for_protected_keys(schema)
 
-    schema = add_missing_defs(schema)
+    schema = _add_missing_defs(schema)  # pyright: ignore[reportDeprecated]
     schema = _remove_empty_defs(schema)
     schema, _ = fix_non_object_root(schema)
 


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4120/error-with-preview-endpoint-an-files

Goes with https://github.com/WorkflowAI/WorkflowAI/pull/23
I initially thought that the frontend change would be enough but backend changes are required since in the case where the user add a document / image field itself, the frontend does not have the `$defs`.