### PR TITLE
When logged in with personal email hide company specific section

### DIFF
--- a/api/api/routers/features.py
+++ b/api/api/routers/features.py
@@ -38,7 +38,7 @@ async def list_feature_sections(user: UserDep) -> FeatureSectionResponse:
         # Since user.tenant is not always the user's email domain, we use the email domain to fill the "For You" section
         user_domain = safe_domain_from_email(user.sub)
 
-    return FeatureSectionResponse(sections=FeatureService.get_feature_sections_preview(user_domain))
+    return FeatureSectionResponse(sections=await FeatureService.get_feature_sections_preview(user_domain))
 
 
 class FeatureListResponse(BaseModel):

--- a/api/api/services/features_test.py
+++ b/api/api/services/features_test.py
@@ -38,47 +38,84 @@ from tests.utils import mock_aiter
 
 
 class TestFeatureService:
-    def test_get_feature_sections_preview(self) -> None:
-        result = FeatureService.get_feature_sections_preview()
-        expected_result = [
-            FeatureSectionPreview(
-                name="Categories",
-                tags=[
-                    FeatureSectionPreview.TagPreview(
-                        name="",
-                        kind="company_specific",
-                    ),  # Placeholder for where the company-specific features will go.
-                    FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Marketing", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Productivity", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Social", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Developer Tools", kind="static"),
-                ],
-            ),
-            FeatureSectionPreview(
-                name="Inspired by",
-                tags=[
-                    FeatureSectionPreview.TagPreview(name="Apple, Google, Amazon", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Our Customers", kind="static"),
-                ],
-            ),
-            FeatureSectionPreview(
-                name="Use Cases",
-                tags=[
-                    FeatureSectionPreview.TagPreview(name="PDFs and Documents", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Scraping", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Image", kind="static"),
-                    FeatureSectionPreview.TagPreview(name="Audio", kind="static"),
-                ],
-            ),
-        ]
+    async def test_get_feature_sections_preview_company_email_domain(self) -> None:
+        with patch.object(FeatureService, "_is_company_email_domain", return_value=True):
+            result = await FeatureService.get_feature_sections_preview()
+            expected_result = [
+                FeatureSectionPreview(
+                    name="Categories",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(
+                            name="",
+                            kind="company_specific",
+                        ),  # Placeholder for where the company-specific features will go.
+                        FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Marketing", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Productivity", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Social", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Developer Tools", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Inspired by",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="Apple, Google, Amazon", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Our Customers", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Use Cases",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="PDFs and Documents", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Scraping", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Image", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Audio", kind="static"),
+                    ],
+                ),
+            ]
 
-        assert result == expected_result
+            assert result == expected_result
 
-    def test_get_feature_sections_preview_with_user_domain(self) -> None:
-        result = FeatureService.get_feature_sections_preview(user_domain="example.com")
+    async def test_get_feature_sections_preview_personal_email_domain(self) -> None:
+        with patch.object(FeatureService, "_is_company_email_domain", return_value=False):
+            result = await FeatureService.get_feature_sections_preview()
+            expected_result = [
+                FeatureSectionPreview(
+                    name="Categories",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Marketing", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Productivity", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Social", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Developer Tools", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Inspired by",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="Apple, Google, Amazon", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Our Customers", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Use Cases",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="PDFs and Documents", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Scraping", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Image", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Audio", kind="static"),
+                    ],
+                ),
+            ]
+
+            assert result == expected_result
+
+    async def test_get_feature_sections_preview_with_user_domain(self) -> None:
+        result = await FeatureService.get_feature_sections_preview(user_domain="example.com")
         expected_result = expected_result = [
             FeatureSectionPreview(
                 name="Categories",

--- a/api/api/tasks/company_domain_from_email_agent.py
+++ b/api/api/tasks/company_domain_from_email_agent.py
@@ -20,7 +20,7 @@ class ClassifyEmailDomainAgentOutput(BaseModel):
     )
 
 
-@workflowai.agent(id="classify-email-domain", model=Model.GPT_4O_MINI_LATEST)
+@workflowai.agent(id="classify-email-domain", model=Model.GEMINI_2_0_FLASH_001)  # blazing fast and high reasoning model
 async def run_classify_email_domain_agent(
     input: ClassifyEmailDomainAgentInput,
 ) -> ClassifyEmailDomainAgentOutput:


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4042/when-logged-in-with-personal-email-company-url=personal-email-domain