### PR TITLE
Correct company section logic

### DIFF
--- a/api/api/services/features.py
+++ b/api/api/services/features.py
@@ -87,11 +87,8 @@ class FeatureService:
         self.storage = storage
 
     @staticmethod
-    async def _is_company_email_domain(user_email_domain: str | None) -> bool:
+    async def _is_company_email_domain(user_email_domain: str) -> bool:
         try:
-            if not user_email_domain:
-                return False
-
             company_domain_classification = await run_classify_email_domain_agent(
                 ClassifyEmailDomainAgentInput(email_domain=user_email_domain),
             )
@@ -104,7 +101,7 @@ class FeatureService:
 
     @staticmethod
     async def get_feature_sections_preview(user_domain: str | None = None) -> list[FeatureSectionPreview]:
-        is_company_email_domain = await FeatureService._is_company_email_domain(user_domain)
+        show_company_section = user_domain is None or await FeatureService._is_company_email_domain(user_domain)
 
         return [
             FeatureSectionPreview(
@@ -118,7 +115,7 @@ class FeatureService:
                     )
                     for tag in section.tags
                     # If the user's email domain is not a company email domain, we don't want to show the "company_specific" section
-                    if tag.kind != "company_specific" or is_company_email_domain
+                    if tag.kind != "company_specific" or show_company_section
                 ],
             )
             for section in FEATURES_MAPPING

--- a/api/api/services/features_test.py
+++ b/api/api/services/features_test.py
@@ -40,7 +40,47 @@ from tests.utils import mock_aiter
 class TestFeatureService:
     async def test_get_feature_sections_preview_company_email_domain(self) -> None:
         with patch.object(FeatureService, "_is_company_email_domain", return_value=True):
-            result = await FeatureService.get_feature_sections_preview()
+            result = await FeatureService.get_feature_sections_preview(user_domain="example.com")
+            expected_result = [
+                FeatureSectionPreview(
+                    name="Categories",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(
+                            name="example.com",
+                            kind="company_specific",
+                        ),  # Placeholder for where the company-specific features will go.
+                        FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Marketing", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Productivity", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Social", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Developer Tools", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Inspired by",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="Apple, Google, Amazon", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Our Customers", kind="static"),
+                    ],
+                ),
+                FeatureSectionPreview(
+                    name="Use Cases",
+                    tags=[
+                        FeatureSectionPreview.TagPreview(name="PDFs and Documents", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Scraping", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Image", kind="static"),
+                        FeatureSectionPreview.TagPreview(name="Audio", kind="static"),
+                    ],
+                ),
+            ]
+
+            assert result == expected_result
+
+    async def test_get_feature_sections_preview_empty_user_domain(self) -> None:
+        with patch.object(FeatureService, "_is_company_email_domain", return_value=True):
+            result = await FeatureService.get_feature_sections_preview(user_domain=None)
             expected_result = [
                 FeatureSectionPreview(
                     name="Categories",
@@ -80,7 +120,7 @@ class TestFeatureService:
 
     async def test_get_feature_sections_preview_personal_email_domain(self) -> None:
         with patch.object(FeatureService, "_is_company_email_domain", return_value=False):
-            result = await FeatureService.get_feature_sections_preview()
+            result = await FeatureService.get_feature_sections_preview(user_domain="example.com")
             expected_result = [
                 FeatureSectionPreview(
                     name="Categories",


### PR DESCRIPTION
@guillaq @jacekzimonski I have corrected the logic of the backend. When user is anonymous we want to indeed display the company section to allow the user to enter any URL. @jacekzimonski if you are blocked by this change and want to merge you can QA and approve this (very small) backend change.