### PR TITLE
Cleanup json dict in runner

### DIFF
--- a/api/core/runners/workflowai/utils.py
+++ b/api/core/runners/workflowai/utils.py
@@ -24,6 +24,7 @@ from core.runners.workflowai.internal_tool import InternalTool
 from core.tools import ToolKind
 from core.utils.file_utils.file_utils import guess_content_type
 from core.utils.schema_sanitation import get_file_format
+from core.utils.strings import clean_unicode_chars
 
 _logger = logging.getLogger(__file__)
 
@@ -315,3 +316,13 @@ async def convert_pdf_to_images(pdf_file: FileWithKeyPath) -> list[FileWithKeyPa
         return FileWithKeyPath(data=image_base64, content_type="image/jpeg", key_path=pdf_file.key_path + [idx])
 
     return [_map(image, i) for i, image in enumerate(images)]
+
+
+def cleanup_provider_json(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: cleanup_provider_json(v) for k, v in obj.items()}  # pyright: ignore[reportUnknownVariableType]
+    if isinstance(obj, list):
+        return [cleanup_provider_json(v) for v in obj]  # pyright: ignore[reportUnknownVariableType]
+    if isinstance(obj, str):
+        return clean_unicode_chars(obj)
+    return obj

--- a/api/core/runners/workflowai/utils_test.py
+++ b/api/core/runners/workflowai/utils_test.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -18,6 +19,7 @@ from tests.utils import fixture_bytes
 from .utils import (
     FileWithKeyPath,
     _process_ref,  # pyright: ignore[reportPrivateUsage]
+    cleanup_provider_json,
     convert_pdf_to_images,
     download_file,
     extract_files,
@@ -518,3 +520,10 @@ class TestProcessRef:
 
         mock_replace_file_in_payload.assert_called_once()
         mock_recursive_find_files.assert_not_called()
+
+
+class TestCleanupProviderJson:
+    async def test_double_nulls(self):
+        raw_json = '{"blabla":["Pr\\u0000e9paration de commande"]}'
+        raw_obj = json.loads(raw_json)
+        assert cleanup_provider_json(raw_obj) == {"blabla": ["Préparation de commande"]}

--- a/api/core/runners/workflowai/workflowai_runner.py
+++ b/api/core/runners/workflowai/workflowai_runner.py
@@ -49,6 +49,7 @@ from core.runners.workflowai.tool_cache import ToolCache
 from core.runners.workflowai.utils import (
     FileWithKeyPath,
     ToolCallRecursionError,
+    cleanup_provider_json,
     convert_pdf_to_images,
     download_file,
     extract_files,
@@ -65,7 +66,6 @@ from core.utils.schema_augmentation_utils import (
     add_reasoning_steps_to_schema,
 )
 from core.utils.schemas import clean_json_string, is_schema_only_containing_one_property
-from core.utils.strings import clean_unicode_chars
 from core.utils.templates import InvalidTemplateError, TemplateManager
 
 from .workflowai_options import WorkflowAIRunnerOptions
@@ -533,7 +533,6 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
         # Acting on the string is probably unefficient, we do multiple decodes and encode
         # On the payload. Instead we should probably retrieve bytes for the output
         # and act on that.
-        json_str = clean_unicode_chars(json_str)
         json_str = clean_json_string(json_str)
 
         try:
@@ -546,6 +545,7 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
             )
             # When the normal json parsing fails, we try and decode it with a tolerant stream handler
             json_dict = parse_tolerant_json(json_str)
+        json_dict = cleanup_provider_json(json_dict)
 
         return self.validate_output_dict(json_dict, partial=partial)
 

--- a/api/core/runners/workflowai/workflowai_runner_test.py
+++ b/api/core/runners/workflowai/workflowai_runner_test.py
@@ -1267,6 +1267,11 @@ Total : 650 kcal, 105g de glucides, 28g de protéines, 7g de lipides""",
         assert raw.reasoning_steps is None
         assert raw.agent_run_result is None
 
+    def test_invalid_unicode_chars(self, patched_runner: WorkflowAIRunner):
+        txt = '{"hello": "hello\\u000009"}'
+        output = patched_runner.output_factory(txt)
+        assert output.output == {"hello": "helloé"}
+
 
 class TestInit:
     @pytest.mark.parametrize("disable_fallback", [False, True])

--- a/api/core/runners/workflowai/workflowai_runner_test.py
+++ b/api/core/runners/workflowai/workflowai_runner_test.py
@@ -1270,7 +1270,7 @@ Total : 650 kcal, 105g de glucides, 28g de protéines, 7g de lipides""",
     def test_invalid_unicode_chars(self, patched_runner: WorkflowAIRunner):
         txt = '{"hello": "hello\\u000009"}'
         output = patched_runner.output_factory(txt)
-        assert output.output == {"hello": "helloé"}
+        assert output.output == {"hello": "hello\t"}
 
 
 class TestInit:

--- a/api/tests/fixtures/openai/invalid_unicode_chars.json
+++ b/api/tests/fixtures/openai/invalid_unicode_chars.json
@@ -32,7 +32,7 @@
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "{\n  \"greeting\": \"The\ud83d\udc00 meaning of life is Pr\u0000e9paration de co😁mmande.\"\n}"
+        "content": "{\n  \"greeting\": \"The\\ud83d\\udc00 meaning of life is Pr\\u0000e9paration de co😁mmande.\"\n}"
       },
       "content_filter_results": {
         "hate": {

--- a/api/tests/integration/run/run_v1_test.py
+++ b/api/tests/integration/run/run_v1_test.py
@@ -2009,11 +2009,13 @@ async def test_invalid_unicode_chars(test_client: IntegrationTestClient):
     task = await test_client.create_task()
     test_client.mock_openai_call(bytes=fixture_bytes("openai", "invalid_unicode_chars.json"))
 
+    expected_str = "The🐀 meaning of life is Préparation de co😁mmande."
+
     res = await test_client.run_task_v1(task, model=Model.GPT_4O_2024_11_20)
-    assert res["task_output"]["greeting"] == "The🐀 meaning of life is Préparation de co😁mmande."
+    assert res["task_output"]["greeting"] == expected_str, "invalid output from run"
 
     # Checking that the run was properly stored
     # Trying to make sure we din't get a surrogate not allowed
     # It would be nice to test with invalid surrogates, but it is hard to reproduce a failing payload
     fetched = await test_client.fetch_run(task, run_id=res["id"])
-    assert fetched["task_output"]["greeting"] == "The🐀 meaning of life is Préparation de co😁mmande."
+    assert fetched["task_output"]["greeting"] == expected_str, "invalid output from fetch"


### PR DESCRIPTION
There was an issue with the test data. Unicode characters in JSON are double encoded meaning that it is the literal character "\" followed by the unicode hex value. So it looks like `\\u...` when serialized which I missed.

https://linear.app/workflowai/issue/WOR-4065/issue-with-models-returning-invalid-unicode-characters