### PR TITLE
use items instead of item_type in schema

### DIFF
--- a/api/api/services/internal_tasks/internal_tasks_service_test.py
+++ b/api/api/services/internal_tasks/internal_tasks_service_test.py
@@ -1319,12 +1319,12 @@ class TestInternalTasksServiceHelpers:
                     fields=[
                         InputArrayFieldConfig(
                             name="meal_plan",
-                            item_type=InputObjectFieldConfig(
+                            items=InputObjectFieldConfig(
                                 name="daily_meals",
                                 fields=[
                                     InputArrayFieldConfig(
                                         name="meals",
-                                        item_type=InputObjectFieldConfig(
+                                        items=InputObjectFieldConfig(
                                             name="meal",
                                             fields=[
                                                 InputGenericFieldConfig(

--- a/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task.py
+++ b/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task.py
@@ -90,7 +90,7 @@ class InputObjectFieldConfig(BaseFieldConfig):
 
 class InputArrayFieldConfig(BaseFieldConfig):
     type: Literal["array"] = "array"
-    item_type: InputItemType = Field(default=None, description="The type of the items in the array")
+    items: InputItemType = Field(default=None, description="The type of the items in the array")
 
 
 class OutputGenericFieldConfig(BaseFieldConfig):
@@ -104,7 +104,7 @@ class OutputObjectFieldConfig(BaseFieldConfig):
 
 class OutputArrayFieldConfig(BaseFieldConfig):
     type: Literal["array"] = "array"
-    item_type: OutputItemType = Field(default=None, description="The type of the items in the array")
+    items: OutputItemType = Field(default=None, description="The type of the items in the array")
 
 
 class ChatMessageWithExtractedURLContent(ChatMessage):

--- a/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task_utils.py
+++ b/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task_utils.py
@@ -62,7 +62,7 @@ def _handle_array_field(
     defs: dict[str, Any],
 ) -> dict[str, Any]:
     """Handle ArrayFieldConfig conversion."""
-    items_schema = convert_field_to_json_schema(field.item_type, defs)
+    items_schema = convert_field_to_json_schema(field.items, defs)
     return {
         "type": "array",
         "items": items_schema,

--- a/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task_utils_test.py
+++ b/api/core/agents/chat_task_schema_generation/chat_task_schema_generation_task_utils_test.py
@@ -268,7 +268,7 @@ from .chat_task_schema_generation_task_utils import (
         (  # Array field
             InputArrayFieldConfig(
                 name="test_array",
-                item_type=InputGenericFieldConfig(
+                items=InputGenericFieldConfig(
                     name="item1",
                     type=InputSchemaFieldType.STRING,
                     description="An item",
@@ -285,14 +285,14 @@ from .chat_task_schema_generation_task_utils import (
         (  # Array field without description
             InputArrayFieldConfig(
                 name="test_array",
-                item_type=InputGenericFieldConfig(name="item1", type=InputSchemaFieldType.STRING),
+                items=InputGenericFieldConfig(name="item1", type=InputSchemaFieldType.STRING),
             ),
             {"type": "array", "items": {"type": "string"}},
         ),
         (  # Output array without description
             OutputArrayFieldConfig(
                 name="test_array",
-                item_type=OutputStringFieldConfig(name="item1"),
+                items=OutputStringFieldConfig(name="item1"),
             ),
             {"type": "array", "items": {"type": "string"}},
         ),
@@ -432,7 +432,7 @@ from .chat_task_schema_generation_task_utils import (
                 fields=[
                     InputArrayFieldConfig(
                         name="test_array",
-                        item_type=InputGenericFieldConfig(
+                        items=InputGenericFieldConfig(
                             name="item1",
                             type=InputSchemaFieldType.STRING,
                             description="First item",
@@ -459,7 +459,7 @@ from .chat_task_schema_generation_task_utils import (
                 fields=[
                     InputArrayFieldConfig(
                         name="test_array",
-                        item_type=InputGenericFieldConfig(name="item1", type=InputSchemaFieldType.STRING),
+                        items=InputGenericFieldConfig(name="item1", type=InputSchemaFieldType.STRING),
                     ),
                 ],
             ),
@@ -479,7 +479,7 @@ from .chat_task_schema_generation_task_utils import (
                 fields=[
                     OutputArrayFieldConfig(
                         name="test_array",
-                        item_type=OutputStringFieldConfig(name="item1"),
+                        items=OutputStringFieldConfig(name="item1"),
                     ),
                 ],
             ),
@@ -509,7 +509,7 @@ from .chat_task_schema_generation_task_utils import (
                     ),
                     InputArrayFieldConfig(
                         name="sections",
-                        item_type=InputObjectFieldConfig(
+                        items=InputObjectFieldConfig(
                             name="section",
                             fields=[
                                 InputGenericFieldConfig(name="section_title", type=InputSchemaFieldType.STRING),
@@ -517,7 +517,7 @@ from .chat_task_schema_generation_task_utils import (
                                 EnumFieldConfig(name="section_type", values=["chapter", "appendix", "reference"]),
                                 InputArrayFieldConfig(
                                     name="attachments",
-                                    item_type=InputObjectFieldConfig(
+                                    items=InputObjectFieldConfig(
                                         name="attachment",
                                         fields=[
                                             InputGenericFieldConfig(name="filename", type=InputSchemaFieldType.STRING),
@@ -598,7 +598,7 @@ from .chat_task_schema_generation_task_utils import (
                     ),
                     OutputArrayFieldConfig(
                         name="results",
-                        item_type=OutputObjectFieldConfig(
+                        items=OutputObjectFieldConfig(
                             name="result",
                             fields=[
                                 OutputStringFieldConfig(name="category", description="Result category"),
@@ -606,7 +606,7 @@ from .chat_task_schema_generation_task_utils import (
                                 EnumFieldConfig(name="confidence_level", values=["high", "medium", "low"]),
                                 OutputArrayFieldConfig(
                                     name="findings",
-                                    item_type=OutputObjectFieldConfig(
+                                    items=OutputObjectFieldConfig(
                                         name="finding",
                                         fields=[
                                             OutputStringFieldConfig(


### PR DESCRIPTION
Closes [WOR-4202: Investigate generation error of the agent builder](https://linear.app/workflowai/issue/WOR-4202/investigate-generation-error-of-the-agent-builder)

This is a simple change but sneaky to find. It seemed that the `item_type` naming was confusing the model into outputting "string" instead of {"type": "string"}. 

I now use "items" which align with the JSON schema standards and is less ambiguous.

I don't think we need to hotfix since errors are unfrequent. I'd rather have some time in staging to observe if we get more generation errors. But by generating all the schemas for the landing page, I didn't get errors, so that looks really good.

Can't wait for struct gen at Anthropic...