### PR TITLE
deactivate company specific section in the landing and new task screen

### DIFF
--- a/api/api/services/features.py
+++ b/api/api/services/features.py
@@ -117,8 +117,13 @@ class FeatureService:
 
     @staticmethod
     async def get_feature_sections_preview(user_domain: str | None = None) -> list[FeatureSectionPreview]:
+        # Feature flag to show company specific section, see https://linear.app/workflowai/issue/WOR-4190/hide-email-domain-specific-feature-suggestions
+        SHOW_COMPANY_SECTION = False
+
         # We want to show company specific section for anonymous user because they must be able to enter any URL and get suggestion for this URL.
-        show_company_section = user_domain is None or await FeatureService._is_company_email_domain(user_domain)
+        show_company_section = SHOW_COMPANY_SECTION and (
+            user_domain is None or await FeatureService._is_company_email_domain(user_domain)
+        )
 
         return [
             FeatureSectionPreview(

--- a/api/api/services/features_test.py
+++ b/api/api/services/features_test.py
@@ -52,10 +52,6 @@ class TestFeatureService:
                 FeatureSectionPreview(
                     name="Categories",
                     tags=[
-                        FeatureSectionPreview.TagPreview(
-                            name="example.com",
-                            kind="company_specific",
-                        ),  # Placeholder for where the company-specific features will go.
                         FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
                         FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
                         FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
@@ -91,10 +87,6 @@ class TestFeatureService:
             FeatureSectionPreview(
                 name="Categories",
                 tags=[
-                    FeatureSectionPreview.TagPreview(
-                        name="",
-                        kind="company_specific",
-                    ),  # Placeholder for where the company-specific features will go.
                     FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
                     FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
                     FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),
@@ -166,7 +158,6 @@ class TestFeatureService:
             FeatureSectionPreview(
                 name="Categories",
                 tags=[
-                    FeatureSectionPreview.TagPreview(name="example.com", kind="company_specific"),
                     FeatureSectionPreview.TagPreview(name="Featured", kind="static"),
                     FeatureSectionPreview.TagPreview(name="E-Commerce", kind="static"),
                     FeatureSectionPreview.TagPreview(name="Healthcare", kind="static"),


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4190/hide-email-domain-specific-feature-suggestions

FYI @jacekzimonski 