### PR TITLE
Add a specific tool call to update field description to the meta agent

### DIFF
--- a/api/api/services/internal_tasks/meta_agent_service.py
+++ b/api/api/services/internal_tasks/meta_agent_service.py
@@ -714,13 +714,30 @@ class MetaAgentService:
                 ),
             )
 
-        if meta_agent_output.edit_schema_tool_call:
+        # Schema description and examples tool call from the meta-agent is mapped to "Improve Prompt" feature in the frontend,
+        # which can update the schema description and examples
+        if meta_agent_output.edit_schema_description_and_examples_tool_call:
+            return ImprovePromptToolCall(
+                run_id=None,
+                run_feedback_message=meta_agent_output.edit_schema_description_and_examples_tool_call.description_and_examples_edition_request_message
+                or "",
+                auto_run=self._resolve_auto_run(
+                    tool_call_type=ImprovePromptToolCall,
+                    initial_auto_run=_reverse_optional_bool(
+                        meta_agent_output.edit_schema_description_and_examples_tool_call.ask_user_confirmation,
+                    )
+                    or False,
+                    messages=messages,
+                ),
+            )
+
+        if meta_agent_output.edit_schema_structure_tool_call:
             return EditSchemaToolCall(
-                edition_request_message=meta_agent_output.edit_schema_tool_call.edition_request_message,
+                edition_request_message=meta_agent_output.edit_schema_structure_tool_call.edition_request_message,
                 auto_run=self._resolve_auto_run(
                     tool_call_type=EditSchemaToolCall,
                     initial_auto_run=_reverse_optional_bool(
-                        meta_agent_output.edit_schema_tool_call.ask_user_confirmation,
+                        meta_agent_output.edit_schema_structure_tool_call.ask_user_confirmation,
                     )
                     or False,
                     messages=messages,


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4198/playground-agent-updates-schema-to-update-description

As the meta agent was really struggling to understand that schema field description and example edits are made by the improve prompt feature, I have created a tool for the meta agent which is about editing schemas fields descriptions and examples. The tool maps to the improve prompt feature in the frontend this way there is no ambiguity anymore. 

I've done some QA myself, and the results are good, but I cannot really replay the failing run for prod because the schema has changed and instructions weren't enough to fix the problem. 