### PR TITLE
Extract extra dependency tests

### DIFF
--- a/.github/workflows/.api-quality.yml
+++ b/.github/workflows/.api-quality.yml
@@ -173,10 +173,8 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install
-      # Setup ffmpeg with tool cache
-      - uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
       - name: Install ubuntu dependencies
-        run: sudo apt-get install -y poppler-utils
+        run: sudo apt-get install -y poppler-utils ffmpeg
       # Run all tests in the app and tests directories
       - name: Run Unit Tests
         run: PYTHONPATH=. poetry run pytest api/tests/integration -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml -m "poppler or ffmpeg"

--- a/.github/workflows/.api-quality.yml
+++ b/.github/workflows/.api-quality.yml
@@ -66,14 +66,66 @@ jobs:
       - name: Pyright
         run: poetry run pyright
 
-      # Setup ffmpeg with tool cache
-      - uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
       # Run all tests in the app and tests directories except integration tests
       - name: Run Unit Tests
-        run: PYTHONPATH=. poetry run pytest . -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml --ignore=api/tests/LLM_tests --ignore=api/tests/e2e --ignore=api/tests/integration
+        run: PYTHONPATH=. poetry run pytest . -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml --ignore=api/tests/LLM_tests --ignore=api/tests/e2e --ignore=api/tests/integration -m "not poppler and not ffmpeg"
 
   # Run integration tests separately
   api-integration:
+    if: inputs.skip != true
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:latest
+        env:
+          MONGO_INITDB_ROOT_USERNAME: admin
+          MONGO_INITDB_ROOT_PASSWORD: admin
+        ports:
+          - 27017:27017
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+      azurite:
+        # Container used to check blob storage connection
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+      clickhouse:
+        image: clickhouse/clickhouse-server:latest
+        ports:
+          - 8123:8123
+          - 9000:9000
+        env:
+          CLICKHOUSE_DB: db_int_test
+          CLICKHOUSE_PASSWORD: admin
+          CLICKHOUSE_USER: default
+    # No need to wait for mongo to be ready here
+    # It will likely be ready by the time we run tests
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Poetry
+        run: pipx install poetry==1.8.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: poetry
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install
+      # Run all tests in the app and tests directories
+      - name: Run Unit Tests
+        run: PYTHONPATH=. poetry run pytest api/tests/integration -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml -m "not poppler and not ffmpeg"
+
+  # Run tests that rely on extra dependencies to avoid installing them on all jobs
+  # TODO: we should likely use tool caching instead -> https://github.com/actions/toolkit/tree/main/packages/tool-cache
+  api-external-dependencies:
     if: inputs.skip != true
     runs-on: ubuntu-latest
     services:
@@ -127,4 +179,4 @@ jobs:
         run: sudo apt-get install -y poppler-utils
       # Run all tests in the app and tests directories
       - name: Run Unit Tests
-        run: PYTHONPATH=. poetry run pytest api/tests/integration -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml
+        run: PYTHONPATH=. poetry run pytest api/tests/integration -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -vv --junitxml=junit/test-results.xml -m "poppler or ffmpeg"

--- a/api/core/providers/google/google_provider_domain_test.py
+++ b/api/core/providers/google/google_provider_domain_test.py
@@ -71,6 +71,7 @@ class TestGoogleMessageFromDomain:
         assert google_message.parts[1].fileData.mimeType == "image/png"
         assert google_message.role == "user"
 
+    @pytest.mark.ffmpeg
     async def test_with_file_audio(self):
         # Test with text content
         text_message = Message(role=Message.Role.USER, content="Hello, world!")

--- a/api/core/utils/audio_test.py
+++ b/api/core/utils/audio_test.py
@@ -1,19 +1,24 @@
+import pytest
+
 from core.utils.audio import audio_duration_seconds
 from tests.utils import fixture_bytes
 
 
 class TestAudioDurationSeconds:
+    @pytest.mark.ffmpeg
     async def test_audio_duration_seconds_wav(self):
         bs = fixture_bytes("files/test.wav")
         dur = await audio_duration_seconds(bs, "audio/wav")
         assert dur == 3
 
+    @pytest.mark.ffmpeg
     async def test_audio_duration_seconds_mp3(self):
         # This test requires ffmpeg to be installed
         bs = fixture_bytes("files/sample.mp3")
         dur = await audio_duration_seconds(bs, "audio/mpeg")
         assert dur == 10.043
 
+    @pytest.mark.ffmpeg
     async def test_audio_duration_seconds_flac(self):
         bs = fixture_bytes("files/sample.flac")
         dur = await audio_duration_seconds(bs, "audio/flac")

--- a/api/tests/integration/run/run_openai_test.py
+++ b/api/tests/integration/run/run_openai_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from core.domain.models import Model
 from core.domain.models.utils import get_model_data
 from tests.integration.common import IntegrationTestClient, openai_endpoint
@@ -63,6 +65,7 @@ async def test_unmarked_image_url(test_client: IntegrationTestClient):
     }
 
 
+@pytest.mark.poppler
 async def test_pdf_conversion(test_client: IntegrationTestClient):
     """Check that we correctly convert PDFs to images when the model supports it"""
 


### PR DESCRIPTION
I got super annoyed at the apt-get install or ffmpeg install failing quite often. Now the tests are in a separate job that does not block merges.