### PR TITLE
[WOR-4250] Don't scroll to top on: Workflowai.com/apple.com when changing search

### DIFF
--- a/client/src/app/landing/URLLandingPage.tsx
+++ b/client/src/app/landing/URLLandingPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { LandingPageContainer } from './container/LandingPageContainer';
 import { URLHeaderComponent } from './sections/Components/HeaderComponent';
 import { SuggestedFeaturesComponent } from './sections/SuggestedFeatures/SuggestedFeaturesComponent';
@@ -10,7 +10,12 @@ type URLLandingPageProps = {
 };
 
 export function URLLandingPage(props: URLLandingPageProps) {
-  const { companyURL } = props;
+  const { companyURL: queryCompanyURL } = props;
+
+  const [companyURL, setCompanyURL] = useState(queryCompanyURL);
+  useEffect(() => {
+    setCompanyURL(queryCompanyURL);
+  }, [queryCompanyURL]);
 
   const scrollToPricing = useCallback(() => {
     const pricingSection = document.getElementById('pricing');
@@ -22,7 +27,12 @@ export function URLLandingPage(props: URLLandingPageProps) {
   return (
     <LandingPageContainer scrollToPricing={scrollToPricing}>
       <URLHeaderComponent className='mt-20' />
-      <SuggestedFeaturesComponent className='mt-2 mb-28' companyURL={companyURL} hideSidebar={true} />
+      <SuggestedFeaturesComponent
+        className='mt-2 mb-28'
+        companyURL={companyURL}
+        setCompanyURL={setCompanyURL}
+        hideSidebar={true}
+      />
     </LandingPageContainer>
   );
 }

--- a/client/src/app/landing/sections/SuggestedFeatures/SuggestedFeaturesSearch.tsx
+++ b/client/src/app/landing/sections/SuggestedFeatures/SuggestedFeaturesSearch.tsx
@@ -62,6 +62,7 @@ export function SuggestedFeaturesSearch(props: Props) {
       } else {
         redirectWithParams({
           path: `/${cleanedURL}`,
+          scroll: false,
         });
       }
 


### PR DESCRIPTION
**Closes:**
https://linear.app/workflowai/issue/WOR-4250/dont-scroll-to-top-on-workflowaicomapplecom-when-changing-search

@pierrevalade @anyacherniss 
When we changed the redirect after entering the company URL from query parameter to new url (workflowai.com/apple.com), we started loading a new page. So the scroll automatically scrolls to top (becasue now it's a new url). 

To overcome this behaviour, we still use the company url from our url, but when the parameter changes we don't redirect to new url. 
- But made sure that the copy button still copies the correct url!
- It also does not scroll to top anymore

**Demo:**
![Screen Recording 2025-04-14 at 5 50 22 PM](https://github.com/user-attachments/assets/21a1d47c-f144-4df5-8db6-14f69446a245)
