### PR TITLE
[WOR-2377] Make it possible to edit input when run is loading

### DIFF
--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/RunAgentsButton.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/RunAgentsButton.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 
 type Props = {
   showSaveAllVersions: boolean;
-  singleTaskLoading: boolean;
+  areTasksRunning: boolean;
   inputLoading: boolean;
   areInstructionsLoading: boolean;
   className?: string;
@@ -18,7 +18,7 @@ type Props = {
 export function RunAgentsButton(props: Props) {
   const {
     showSaveAllVersions,
-    singleTaskLoading,
+    areTasksRunning,
     inputLoading,
     areInstructionsLoading,
     className,
@@ -37,7 +37,7 @@ export function RunAgentsButton(props: Props) {
         <Button
           variant='newDesignIndigo'
           icon={<Save16Filled />}
-          loading={singleTaskLoading}
+          loading={areTasksRunning}
           disabled={isSaveButtonDisabled}
           onClick={onSaveAllVersions}
           className={cn('min-h-8', className)}
@@ -55,7 +55,7 @@ export function RunAgentsButton(props: Props) {
       <Button
         variant='newDesignIndigo'
         icon={<Play16Filled />}
-        loading={singleTaskLoading}
+        loading={areTasksRunning}
         disabled={isNormalButtonDisabled}
         onClick={onTryPromptClick}
         className={cn('min-h-8', className)}
@@ -78,7 +78,7 @@ export function RunAgentsButton(props: Props) {
 
   return (
     <div onMouseEnter={() => setIsHovering(true)} onMouseLeave={() => setIsHovering(false)} className={className}>
-      {isHovering && singleTaskLoading ? stopButtonContent : normalButtonContent}
+      {isHovering && areTasksRunning ? stopButtonContent : normalButtonContent}
     </div>
   );
 }

--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundContent.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundContent.tsx
@@ -548,7 +548,7 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
     [findAbortController]
   );
 
-  const onStopAllRuns = useCallback(() => {
+  const stopAllRuns = useCallback(() => {
     abortControllerRun0.current?.abort();
     abortControllerRun1.current?.abort();
     abortControllerRun2.current?.abort();
@@ -774,7 +774,7 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
     [handleGeneratePlaygroundInput, toggleSettingsModal]
   );
 
-  const singleTaskLoading = useMemo(() => taskIndexesLoading.some((l) => l), [taskIndexesLoading]);
+  const areTasksRunning = useMemo(() => taskIndexesLoading.some((l) => l), [taskIndexesLoading]);
 
   // Load the initial task run or trigger the generation of the input and runs
   const { taskRun1, taskRun2, taskRun3, taskRun1Loading, taskRun2Loading, taskRun3Loading } = usePlaygroundEffects({
@@ -1076,11 +1076,11 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
     cancelImproveInstructions();
     onStopGeneratingInput();
     cancelScheduledPlaygroundMessage();
-    onStopAllRuns();
+    stopAllRuns();
     setTimeout(() => {
-      onStopAllRuns();
+      stopAllRuns();
     }, 1000);
-  }, [cancelScheduledPlaygroundMessage, cancelImproveInstructions, onStopGeneratingInput, onStopAllRuns]);
+  }, [cancelScheduledPlaygroundMessage, cancelImproveInstructions, onStopGeneratingInput, stopAllRuns]);
 
   const isMobile = useIsMobile();
 
@@ -1111,12 +1111,12 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
               {!isMobile && (
                 <RunAgentsButton
                   showSaveAllVersions={showSaveAllVersions && !noCreditsLeft}
-                  singleTaskLoading={singleTaskLoading}
+                  areTasksRunning={areTasksRunning}
                   inputLoading={inputLoading}
                   areInstructionsLoading={areInstructionsLoading}
                   onSaveAllVersions={onSaveAllVersions}
                   onTryPromptClick={onTryPromptClick}
-                  onStopAllRuns={onStopAllRuns}
+                  onStopAllRuns={stopAllRuns}
                 />
               )}
             </div>
@@ -1142,7 +1142,7 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
                 oldInstructions={oldInstructions}
                 onEdit={onEdit}
                 onImportInput={onImportInput}
-                singleTaskLoading={singleTaskLoading}
+                areTasksRunning={areTasksRunning}
                 toggleSettingsModal={toggleSettingsModal}
                 instructions={instructions}
                 setInstructions={onSetInstructions}
@@ -1171,6 +1171,7 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
                 onToolsChange={updateTaskInstructions}
                 onStopGeneratingInput={onStopGeneratingInput}
                 isInDemoMode={isInDemoMode}
+                stopAllRuns={stopAllRuns}
               />
               <div ref={playgroundOutputRef} className='flex w-full'>
                 <PlaygroundOutput
@@ -1218,12 +1219,12 @@ export function PlaygroundContent(props: PlaygroundContentBodyProps) {
             <div className='fixed bottom-0 left-0 right-0 z-10 bg-white border-t border-gray-200 p-4 sm:hidden flex w-full'>
               <RunAgentsButton
                 showSaveAllVersions={showSaveAllVersions && !noCreditsLeft}
-                singleTaskLoading={singleTaskLoading}
+                areTasksRunning={areTasksRunning}
                 inputLoading={inputLoading}
                 areInstructionsLoading={areInstructionsLoading}
                 onSaveAllVersions={onSaveAllVersions}
                 onTryPromptClick={onTryPromptClick}
-                onStopAllRuns={onStopAllRuns}
+                onStopAllRuns={stopAllRuns}
                 className='flex w-full'
               />
             </div>

--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundInput.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundInput.tsx
@@ -20,7 +20,7 @@ type PlaygroundInputProps = {
   areInstructionsLoading: boolean;
   onEdit: (keyPath: string, newVal: unknown) => void;
   onImportInput: (importedInput: string) => Promise<void>;
-  singleTaskLoading: boolean;
+  areTasksRunning: boolean;
   toggleSettingsModal: () => void;
   isPreviousAvailable: boolean;
   isNextAvailable: boolean;
@@ -37,6 +37,7 @@ type PlaygroundInputProps = {
   ) => Promise<string | undefined>;
   onStopGeneratingInput: () => void;
   isInDemoMode: boolean;
+  stopAllRuns: () => void;
 };
 
 export function PlaygroundInput(props: PlaygroundInputProps) {
@@ -48,7 +49,7 @@ export function PlaygroundInput(props: PlaygroundInputProps) {
     areInstructionsLoading,
     onEdit,
     onImportInput,
-    singleTaskLoading,
+    areTasksRunning,
     toggleSettingsModal,
     isPreviousAvailable,
     isNextAvailable,
@@ -61,6 +62,7 @@ export function PlaygroundInput(props: PlaygroundInputProps) {
     handleUploadFile,
     onStopGeneratingInput,
     isInDemoMode,
+    stopAllRuns,
   } = props;
 
   const [importModalOpen, setImportModalOpen] = useState(false);
@@ -73,14 +75,17 @@ export function PlaygroundInput(props: PlaygroundInputProps) {
 
   const handleEdit = useCallback(
     (keyPath: string, newVal: unknown) => {
-      if (singleTaskLoading) return;
+      if (areTasksRunning) {
+        stopAllRuns();
+      }
 
       if (inputLoading) {
         onStopGeneratingInput();
       }
+
       onEdit(keyPath, newVal);
     },
-    [onEdit, singleTaskLoading, inputLoading, onStopGeneratingInput]
+    [onEdit, areTasksRunning, inputLoading, onStopGeneratingInput, stopAllRuns]
   );
 
   const voidInput = useMemo(() => {
@@ -136,7 +141,7 @@ export function PlaygroundInput(props: PlaygroundInputProps) {
               variant='newDesign'
               icon={<ArrowUpload16Regular className='h-4 w-4' />}
               onClick={openImportModal}
-              disabled={singleTaskLoading || areInstructionsLoading || inputLoading}
+              disabled={areTasksRunning || areInstructionsLoading || inputLoading}
               className='h-7 w-7 mr-2 sm:block hidden'
               size='none'
             />
@@ -144,7 +149,7 @@ export function PlaygroundInput(props: PlaygroundInputProps) {
             <GenerateInputControls
               onQuickGenerateInput={onQuickGenerateInput}
               inputLoading={inputLoading}
-              singleTaskLoading={singleTaskLoading}
+              singleTaskLoading={areTasksRunning}
               areInstructionsLoading={areInstructionsLoading}
               toggleSettingsModal={toggleSettingsModal}
               onStopGeneratingInput={onStopGeneratingInput}

--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundInputContainer.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundInputContainer.tsx
@@ -22,7 +22,7 @@ type PlaygroundInputContainerProps = {
   approveImprovedInstructions: () => void;
   setInstructions: (value: string) => void;
   setTemperature: (value: number) => void;
-  singleTaskLoading: boolean;
+  areTasksRunning: boolean;
   temperature: number;
   toggleSettingsModal: () => void;
   isPreviousAvailableForParameters: boolean;
@@ -48,6 +48,7 @@ type PlaygroundInputContainerProps = {
   onToolsChange: (tools: ToolKind[]) => Promise<void>;
   onStopGeneratingInput: () => void;
   isInDemoMode: boolean;
+  stopAllRuns: () => void;
 };
 
 export function PlaygroundInputContainer(props: PlaygroundInputContainerProps) {
@@ -69,7 +70,7 @@ export function PlaygroundInputContainer(props: PlaygroundInputContainerProps) {
     approveImprovedInstructions,
     setInstructions,
     setTemperature,
-    singleTaskLoading,
+    areTasksRunning,
     temperature,
     toggleSettingsModal,
     isPreviousAvailableForParameters,
@@ -91,6 +92,7 @@ export function PlaygroundInputContainer(props: PlaygroundInputContainerProps) {
     onToolsChange,
     onStopGeneratingInput,
     isInDemoMode,
+    stopAllRuns,
   } = props;
 
   return (
@@ -103,7 +105,7 @@ export function PlaygroundInputContainer(props: PlaygroundInputContainerProps) {
           inputLoading={inputLoading}
           areInstructionsLoading={areInstructionsLoading}
           onEdit={onEdit}
-          singleTaskLoading={singleTaskLoading}
+          areTasksRunning={areTasksRunning}
           toggleSettingsModal={toggleSettingsModal}
           onImportInput={onImportInput}
           isPreviousAvailable={isPreviousAvailableForInput}
@@ -117,6 +119,7 @@ export function PlaygroundInputContainer(props: PlaygroundInputContainerProps) {
           handleUploadFile={handleUploadFile}
           onStopGeneratingInput={onStopGeneratingInput}
           isInDemoMode={isInDemoMode}
+          stopAllRuns={stopAllRuns}
         />
       </div>
 

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -309,6 +309,10 @@ export async function SSEClient<R, T>(
   let lastMessage: T | undefined;
   const headers = await requestHeaders('application/json');
 
+  if (signal?.aborted) {
+    return undefined as T;
+  }
+
   await fetchEventSource(path, {
     onopen: onOpenStream,
     onmessage: (event: EventSourceMessage) => {


### PR DESCRIPTION
**Closes:**
https://linear.app/workflowai/issue/WOR-2377/make-it-possible-to-edit-input-when-run-is-loading

@anyacherniss 
When implementing the feature found and issue with sometimes the Stop Runs not working even for the buttons.
It was connected to the token change.
Now it should be resolved and Stop / Cancel Run should start working much better.

**Demo:**
![Screen Recording 2025-04-17 at 11 04 07 AM](https://github.com/user-attachments/assets/9ad73d11-cd20-48ef-8cd4-222db8088393)
