### PR TITLE
Order Should Matter When Editing New Schema

### DIFF
--- a/client/src/components/NewTaskModal/NewTaskModal.tsx
+++ b/client/src/components/NewTaskModal/NewTaskModal.tsx
@@ -225,9 +225,8 @@ export function NewTaskModal() {
     if (loading) return true;
     if (!isEditMode) return false;
 
-    const inputIsEqual = areSchemasEquivalent(computedInputSchema as JsonSchema, inputSchemaForVariant);
-
-    const outputIsEqual = areSchemasEquivalent(computedOutputSchema as JsonSchema, outputSchemaForVariant);
+    const inputIsEqual = areSchemasEquivalent(computedInputSchema as JsonSchema, inputSchemaForVariant, true);
+    const outputIsEqual = areSchemasEquivalent(computedOutputSchema as JsonSchema, outputSchemaForVariant, true);
 
     return inputIsEqual && outputIsEqual;
   }, [computedInputSchema, computedOutputSchema, inputSchemaForVariant, outputSchemaForVariant, loading, isEditMode]);


### PR DESCRIPTION
@guillaq @anyacherniss @pierrevalade 
So implemented checking of the order for Property Keys in Schema.
On frontend it's working.
But after saving the modified schema, backend informs us that the schema already exists and redirects to the one with old order.
So the order check to make it work should be also implemented on the backend to make it work.
This PR has the required Frontend part.
@guillaq was informed

![Screen Recording 2025-04-17 at 10 12 47 PM](https://github.com/user-attachments/assets/0a58f2eb-c6b5-4c15-b02d-84475246401d)
