### PR TITLE
[WOR-4401] Potential fix: Improve prompt error (but improve prompt is working)

### DIFF
--- a/client/src/store/task.ts
+++ b/client/src/store/task.ts
@@ -90,7 +90,8 @@ interface TasksState {
     taskSchemaId: TaskSchemaID,
     instructions: string,
     tools: ToolKind[],
-    onMessage: (message: string) => void
+    onMessage: (message: string) => void,
+    signal?: AbortSignal
   ): Promise<string>;
   createTask(tenant: TenantID | undefined, payload: Omit<CreateAgentRequest, 'id'>): Promise<CreateAgentResponse>;
   updateTask(tenant: TenantID | undefined, taskId: TaskID, payload: UpdateTaskRequest): Promise<SerializableTask>;
@@ -272,7 +273,8 @@ export const useTasks = create<TasksState>((set, get) => ({
     taskSchemaId: TaskSchemaID,
     instructions: string,
     tools: ToolKind[],
-    onMessage: (message: string) => void
+    onMessage: (message: string) => void,
+    signal?: AbortSignal
   ): Promise<string> => {
     const lastInstructions = await SSEClient<
       UpdateTaskInstructionsRequest,
@@ -285,7 +287,8 @@ export const useTasks = create<TasksState>((set, get) => ({
         if (message.updated_task_instructions) {
           onMessage(message.updated_task_instructions);
         }
-      }
+      },
+      signal
     );
     return lastInstructions.updated_task_instructions ?? '';
   },


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4401/improve-prompt-error-but-improve-prompt-is-working

Explanation:
@anyacherniss 
Not hundred percent sure if this fix will work, was not eable to replicate this issue.
But that's my best theory.

So:
- I think the issue was when the previous stream failed, but was not cleaned up, and did not show the prompt.
- When the new stream concluded, the previous stream reported error (the one from your previous instruction try), and reported it at the same time as the success
- To prevent that I'm doing two things:
- I'm canceling previous stream from chat as soon as new starts
- I added abortsignal also to instruction change from the outputs, and also canceling it