### PR TITLE
[WOR-4451] Add absolute time tooltip to runs page

### DIFF
--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/runs/taskRunTable/TaskRunTableRow.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/runs/taskRunTable/TaskRunTableRow.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { TaskVersionBadgeContainer } from '@/components/TaskIterationBadge/TaskVersionBadgeContainer';
 import { SimpleTooltip } from '@/components/ui/Tooltip';
-import { formatRelativeTime } from '@/lib/formatters/timeFormatter';
+import { formatDateTime, formatRelativeTime } from '@/lib/formatters/timeFormatter';
 import { useRedirectWithParams } from '@/lib/queryString';
 import { environmentsForVersion } from '@/lib/versionUtils';
 import { RunItemV1, VersionV1 } from '@/types/workflowAI';
@@ -48,6 +48,7 @@ export function TaskRunTableRow(props: TaskRunTableRowProps) {
               'To save this version, open the run details by\ntapping the row and tap Save in the\nVersion section'
             }
             tooltipClassName='whitespace-pre-line text-center'
+            tooltipDelay={100}
           >
             <div className='w-fit flex text-ellipsis whitespace-nowrap h-full items-center justify-center text-gray-700 text-[13px] font-medium rounded-[2px] bg-white border border-gray-200 border-dashed px-1.5 py-[3px]'>
               (not saved)
@@ -56,7 +57,13 @@ export function TaskRunTableRow(props: TaskRunTableRowProps) {
         )}
         {!!environments && environments.length > 0 && <TaskRunEnvironments environments={environments} />}
       </div>
-      <div className='w-[64px] text-gray-500 text-[13px] font-normal'>{formatRelativeTime(runItem.created_at)}</div>
+      <SimpleTooltip
+        content={formatDateTime(runItem.created_at)}
+        tooltipClassName='whitespace-pre-line text-center'
+        tooltipDelay={100}
+      >
+        <div className='w-[64px] text-gray-500 text-[13px] font-normal'>{formatRelativeTime(runItem.created_at)}</div>
+      </SimpleTooltip>
       <div className='w-[60px]'>
         <TaskRunReview taskRun={runItem} />
       </div>

--- a/client/src/lib/formatters/timeFormatter.ts
+++ b/client/src/lib/formatters/timeFormatter.ts
@@ -25,3 +25,8 @@ export function formatRelativeTime(date: string | undefined) {
     .replace(' years', 'y')
     .replace(' year', 'y');
 }
+
+export function formatDateTime(date: string | undefined) {
+  if (!date) return null;
+  return dayjs(date).format('h:mma MMMM D, YYYY');
+}


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4451/add-absolute-time-tooltip-to-runs-page

Screenshot:
<img width="426" alt="Screenshot 2025-05-06 at 10 03 59 AM" src="https://github.com/user-attachments/assets/dc56a742-84ef-4aef-96b1-2d4096dbd3ca" />
