### PR TITLE
[WOR-4670] Redirection bug in onboarding

### DIFF
--- a/client/src/components/NewTaskModal/Import/NewTaskImportFlow.tsx
+++ b/client/src/components/NewTaskModal/Import/NewTaskImportFlow.tsx
@@ -32,10 +32,8 @@ export function NewTaskImportFlow(props: NewTaskFlowChoiceProps) {
   const { messages, isLoading, sendMessage, redirectToAgentPlayground } = useOrFetchIntegrationChat(integration?.id);
 
   useEffect(() => {
-    const taskId = (redirectToAgentPlayground?.task_id ??
-      redirectToAgentPlayground?.agent_name?.toLowerCase()) as TaskID;
-
-    const taskSchemaId = (redirectToAgentPlayground?.task_schema_id ?? '1') as TaskSchemaID;
+    const taskId = redirectToAgentPlayground?.agent_id as TaskID;
+    const taskSchemaId = (redirectToAgentPlayground?.agent_schema_id ?? '1') as TaskSchemaID;
 
     if (!!taskId && !!taskSchemaId) {
       router.push(taskSchemaRoute(tenant, taskId, taskSchemaId));

--- a/client/src/store/integrations_messages.tsx
+++ b/client/src/store/integrations_messages.tsx
@@ -7,9 +7,8 @@ import { API_URL } from '@/lib/constants';
 import { IntegrationChatMessage } from '../types/workflowAI/models';
 
 export type RedirectToAgentPlayground = {
-  agent_name?: string;
-  task_id?: string;
-  task_schema_id?: string;
+  agent_id?: string;
+  agent_schema_id?: number;
 };
 
 export type IntegrationChatResponse = {


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4670/redirection-bug-in-onboarding

Explanation:
On Preview a newer version with different redirect response from backend was deployed that is not compatible with the older one. This PR adjusts the redirect for the new structure.

Important:
It will work when the changes with redirect that are already avaible on Preview will be propagated to dev.
@yannbu will inform when.