### PR TITLE
[WOR-4665] Use Object Viewer to display json objects in proxy playground

### DIFF
--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundModelOutputContent.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/playgroundModelOutputContent.tsx
@@ -182,6 +182,9 @@ export function PlaygroundModelOutputContent(props: ModelOutputContentProps) {
             toolCalls={toolCallsPreview}
             reasoningSteps={reasoningSteps}
             streamLoading={streamLoading}
+            outputSchema={outputSchema}
+            referenceValue={referenceValue}
+            emptyMode={emptyMode}
           />
         ) : (
           <TaskOutputViewer

--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/proxy/ProxyOutputViewer.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/proxy/ProxyOutputViewer.tsx
@@ -1,44 +1,53 @@
-import { useMemo } from 'react';
-import { ObjectViewerPrefixSlot } from '@/components/ObjectViewer/TaskOutputViewer';
-import { ToolCallPreview } from '@/types';
+import { TaskOutputViewer } from '@/components/ObjectViewer/TaskOutputViewer';
+import { cn } from '@/lib/utils';
+import { JsonSchema, ToolCallPreview } from '@/types';
 import { TaskOutput } from '@/types/task_run';
 import { ReasoningStep } from '@/types/workflowAI';
-import { formatResponseToText } from './utils';
 
 type ProxyOutputViewerProps = {
   taskOutput: TaskOutput | undefined;
   toolCalls: ToolCallPreview[] | undefined;
   reasoningSteps: ReasoningStep[] | undefined;
   streamLoading: boolean;
+  outputSchema: JsonSchema | undefined;
+  referenceValue: Record<string, unknown> | undefined;
+  emptyMode: boolean;
 };
 
 export function ProxyOutputViewer(props: ProxyOutputViewerProps) {
-  const { taskOutput, toolCalls, reasoningSteps, streamLoading } = props;
+  const { taskOutput, toolCalls, reasoningSteps, streamLoading, outputSchema, referenceValue, emptyMode } = props;
 
-  const formattedText = useMemo(() => {
-    return formatResponseToText(taskOutput);
-  }, [taskOutput]);
+  if (taskOutput === undefined && (outputSchema === undefined || outputSchema.format === 'message')) {
+    return (
+      <div className='flex flex-col flex-1 w-full bg-white border-b border-gray-200 border-dashed overflow-hidden'>
+        <div className='flex flex-col flex-1 px-4 py-3 gap-1 overflow-hidden'>
+          <div className='text-gray-700 text-[13px] font-medium'>{outputSchema?.format ?? 'message'}:</div>
+          <div className='flex py-0.5 px-1.5 border border-gray-200 rounded-[2px] text-gray-700 text-[13px] font-medium w-fit'>
+            {outputSchema?.type ?? 'string'}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className='flex flex-col flex-1 w-full bg-white border-b border-gray-200 border-dashed overflow-hidden'>
-      <ObjectViewerPrefixSlot
-        streamLoading={streamLoading}
-        toolCalls={toolCalls}
-        reasoningSteps={reasoningSteps}
-        defaultOpenForSteps={true}
-      />
-      <div className='flex flex-col flex-1 px-4 py-3 gap-1 overflow-hidden'>
-        <div className='text-gray-700 text-[13px] font-medium'>assistant message:</div>
-        {formattedText === undefined ? (
-          <div className='flex py-0.5 px-1.5 border border-gray-200 rounded-[2px] text-gray-700 text-[13px] font-medium w-fit'>
-            string
-          </div>
-        ) : (
-          <div className='flex flex-col py-2 px-3 gap-2 border border-gray-200 rounded-[2px] min-h-[100px] overflow-y-auto'>
-            <div className='text-gray-900 text-[13px] font-normal whitespace-pre-wrap'>{formattedText}</div>
-          </div>
-        )}
-      </div>
-    </div>
+    <TaskOutputViewer
+      schema={outputSchema}
+      value={taskOutput}
+      referenceValue={referenceValue}
+      defs={outputSchema?.$defs}
+      textColor='text-gray-900'
+      className={cn(
+        'flex sm:flex-1 w-full border-b border-gray-200 border-dashed bg-white sm:overflow-y-scroll',
+        !!taskOutput && 'min-h-[150px]'
+      )}
+      showTypes={emptyMode}
+      showExamplesHints
+      onShowEditDescriptionModal={undefined}
+      streamLoading={streamLoading}
+      toolCalls={toolCalls}
+      reasoningSteps={reasoningSteps}
+      showDescriptionExamples={undefined}
+    />
   );
 }


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4665/use-objectviewer-to-display-json-objects-in-proxy-playground

Screenshots:
<img width="1440" alt="Screenshot 2025-05-14 at 6 26 00 PM" src="https://github.com/user-attachments/assets/faee7f96-4d9f-48f2-83dd-79fb3e001cc3" />
<img width="491" alt="Screenshot 2025-05-14 at 6 26 13 PM" src="https://github.com/user-attachments/assets/903fd982-455f-4db4-b56a-97b947648002" />
<img width="464" alt="Screenshot 2025-05-14 at 6 27 02 PM" src="https://github.com/user-attachments/assets/59f5a826-9476-4241-8eb5-c453618b1b6e" />
<img width="477" alt="Screenshot 2025-05-14 at 6 27 07 PM" src="https://github.com/user-attachments/assets/d99097b4-e215-4d9a-84ba-94abfe107213" />
