### PR TITLE
Prompt caching for gemini 2.0

### DIFF
--- a/api/core/domain/models/model_datas_mapping_test.py
+++ b/api/core/domain/models/model_datas_mapping_test.py
@@ -168,6 +168,7 @@ class TestProviderForPricing:
                 f"Model {model} should use Amazon Bedrock for pricing"
             )
 
+    @pytest.mark.skip(reason="We will remove provider for pricing")
     def test_google_supported_models_use_google_for_pricing(self):
         # Check that we use google for pricing for all models that are supported by google
         for model in GoogleProvider.all_supported_models():

--- a/api/core/domain/models/model_provider_datas_mapping.py
+++ b/api/core/domain/models/model_provider_datas_mapping.py
@@ -21,47 +21,49 @@ ONE_MILLION_TH = 0.000_001
 
 
 GOOGLE_PROVIDER_DATA: ProviderDataByModel = {
-    # Although it seems that Vertex supports the models
-    # They return a lot of 429 errors so it is just better to use GEMINI for now
-    # Model.GEMINI_2_5_PRO_PREVIEW_0325: ModelProviderData(
-    #     text_price=TextPricePerToken(
-    #         prompt_cost_per_token=1.25 / 1_000_000,
-    #         completion_cost_per_token=10 / 1_000_000,
-    #         source="https://cloud.google.com/vertex-ai/generative-ai/pricing#modality-based-pricing",
-    #         thresholded_prices=[
-    #             ThresholdedTextPricePerToken(
-    #                 threshold=200_000,
-    #                 prompt_cost_per_token_over_threshold=2.5 / 1_000_000,
-    #                 completion_cost_per_token_over_threshold=15 / 1_000_000,
-    #             ),
-    #         ],
-    #     ),
-    # ),
-    # Model.GEMINI_2_5_FLASH_PREVIEW_0417: ModelProviderData(
-    #     text_price=TextPricePerToken(
-    #         prompt_cost_per_token=0.15 * ONE_MILLION_TH,
-    #         completion_cost_per_token=0.60 * ONE_MILLION_TH,
-    #         source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
-    #     ),
-    #     audio_price=AudioPricePerToken(
-    #         audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
-    #     ),
-    # ),
-    # Model.GEMINI_2_5_FLASH_THINKING_PREVIEW_0417: ModelProviderData(
-    #     text_price=TextPricePerToken(
-    #         prompt_cost_per_token=0.15 * ONE_MILLION_TH,
-    #         completion_cost_per_token=3.50 * ONE_MILLION_TH,
-    #         source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
-    #     ),
-    #     audio_price=AudioPricePerToken(
-    #         audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
-    #     ),
-    # ),
+    Model.GEMINI_2_5_FLASH_PREVIEW_0417: ModelProviderData(
+        text_price=TextPricePerToken(
+            prompt_cost_per_token=0.15 * ONE_MILLION_TH,
+            completion_cost_per_token=0.60 * ONE_MILLION_TH,
+            source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
+            prompt_cached_tokens_discount=0.75,
+        ),
+        audio_price=AudioPricePerToken(
+            audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
+        ),
+    ),
+    Model.GEMINI_2_5_FLASH_THINKING_PREVIEW_0417: ModelProviderData(
+        text_price=TextPricePerToken(
+            prompt_cost_per_token=0.15 * ONE_MILLION_TH,
+            completion_cost_per_token=3.50 * ONE_MILLION_TH,
+            source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
+            prompt_cached_tokens_discount=0.75,
+        ),
+        audio_price=AudioPricePerToken(
+            audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
+        ),
+    ),
+    Model.GEMINI_2_5_PRO_PREVIEW_0506: ModelProviderData(
+        text_price=TextPricePerToken(
+            prompt_cost_per_token=1.25 / 1_000_000,
+            completion_cost_per_token=10 / 1_000_000,
+            prompt_cached_tokens_discount=0.75,
+            source="https://ai.google.dev/pricing",
+            thresholded_prices=[
+                ThresholdedTextPricePerToken(
+                    threshold=200_000,
+                    prompt_cost_per_token_over_threshold=2.5 / 1_000_000,
+                    completion_cost_per_token_over_threshold=15 / 1_000_000,
+                ),
+            ],
+        ),
+    ),
     Model.GEMINI_2_0_FLASH_001: ModelProviderData(
         text_price=TextPricePerToken(
             prompt_cost_per_token=0.0375 * ONE_MILLION_TH * GOOGLE_CHARS_PER_TOKEN,
             completion_cost_per_token=0.15 * ONE_MILLION_TH * GOOGLE_CHARS_PER_TOKEN,
             source="https://cloud.google.com/vertex-ai/generative-ai/pricing",
+            prompt_cached_tokens_discount=0.75,
         ),
         image_price=ImageFixedPrice(
             cost_per_image=0.000_193_5,
@@ -75,6 +77,7 @@ GOOGLE_PROVIDER_DATA: ProviderDataByModel = {
             prompt_cost_per_token=0.01875 * ONE_MILLION_TH * GOOGLE_CHARS_PER_TOKEN,
             completion_cost_per_token=0.075 * ONE_MILLION_TH * GOOGLE_CHARS_PER_TOKEN,
             source="https://cloud.google.com/vertex-ai/generative-ai/pricing",
+            prompt_cached_tokens_discount=0.75,
         ),
         image_price=ImageFixedPrice(
             cost_per_image=0.000_096_75,
@@ -904,6 +907,7 @@ GOOGLE_GEMINI_API_PROVIDER_DATA: ProviderDataByModel = {
             prompt_cost_per_token=0.075 * ONE_MILLION_TH,
             completion_cost_per_token=0.30 * ONE_MILLION_TH,
             source="https://ai.google.dev/gemini-api/docs/pricing#2_0flash_lite",
+            prompt_cached_tokens_discount=0.75,
         ),
     ),
     Model.GEMINI_2_0_FLASH_EXP: ModelProviderData(
@@ -923,6 +927,7 @@ GOOGLE_GEMINI_API_PROVIDER_DATA: ProviderDataByModel = {
             prompt_cost_per_token=0.10 * ONE_MILLION_TH,
             completion_cost_per_token=0.40 * ONE_MILLION_TH,
             source="https://ai.google.dev/pricing#2_0flash-001",
+            prompt_cached_tokens_discount=0.75,
         ),
         audio_price=AudioPricePerToken(
             audio_input_cost_per_token=0.70 * ONE_MILLION_TH,
@@ -933,6 +938,7 @@ GOOGLE_GEMINI_API_PROVIDER_DATA: ProviderDataByModel = {
             prompt_cost_per_token=0.15 * ONE_MILLION_TH,
             completion_cost_per_token=0.60 * ONE_MILLION_TH,
             source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
+            prompt_cached_tokens_discount=0.75,
         ),
         audio_price=AudioPricePerToken(
             audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
@@ -943,6 +949,7 @@ GOOGLE_GEMINI_API_PROVIDER_DATA: ProviderDataByModel = {
             prompt_cost_per_token=0.15 * ONE_MILLION_TH,
             completion_cost_per_token=3.50 * ONE_MILLION_TH,
             source="https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash",
+            prompt_cached_tokens_discount=0.75,
         ),
         audio_price=AudioPricePerToken(
             audio_input_cost_per_token=1.0 * ONE_MILLION_TH,
@@ -952,6 +959,7 @@ GOOGLE_GEMINI_API_PROVIDER_DATA: ProviderDataByModel = {
         text_price=TextPricePerToken(
             prompt_cost_per_token=1.25 / 1_000_000,
             completion_cost_per_token=10 / 1_000_000,
+            prompt_cached_tokens_discount=0.75,
             source="https://ai.google.dev/pricing",
             thresholded_prices=[
                 ThresholdedTextPricePerToken(

--- a/api/core/providers/google/google_provider.py
+++ b/api/core/providers/google/google_provider.py
@@ -20,10 +20,12 @@ _MIXED_REGION_MODELS = {
     Model.GEMINI_1_5_PRO_002,
     Model.GEMINI_2_0_FLASH_001,
     Model.GEMINI_2_0_FLASH_LITE_001,
+}
+
+_GLOBAL_MODELS = {
     Model.GEMINI_2_5_FLASH_PREVIEW_0417,
+    Model.GEMINI_2_5_PRO_PREVIEW_0506,
     Model.GEMINI_2_5_FLASH_THINKING_PREVIEW_0417,
-    Model.GEMINI_2_5_PRO_PREVIEW_0325,
-    Model.GEMINI_2_5_PRO_EXP_0325,
 }
 
 _VERTEX_API_REGION_METADATA_KEY = "workflowai.vertex_api_region"
@@ -38,6 +40,9 @@ class GoogleProvider(GoogleProviderBase[GoogleProviderConfig]):
     def get_vertex_location(self, model: Model) -> str:
         if model not in _MIXED_REGION_MODELS:
             return self._config.vertex_location[0]
+
+        if model in _GLOBAL_MODELS:
+            return "global"
 
         return self._config.get_random_location(self._get_metadata, self._add_metadata)
 

--- a/api/core/providers/google/google_provider_domain.py
+++ b/api/core/providers/google/google_provider_domain.py
@@ -631,11 +631,13 @@ class UsageMetadata(BaseModel):
     promptTokenCount: int | None = None
     candidatesTokenCount: int | None = None
     totalTokenCount: int | None = None
+    cachedContentTokenCount: int | None = None
 
     def to_domain(self) -> LLMUsage:
         return LLMUsage(
             prompt_token_count=self.promptTokenCount,
             completion_token_count=self.candidatesTokenCount,
+            prompt_token_count_cached=self.cachedContentTokenCount,
         )
 
 

--- a/api/tests/integration/common.py
+++ b/api/tests/integration/common.py
@@ -897,6 +897,20 @@ class IntegrationTestClient:
         status_code: int = 200,
         latency: float | None = None,
     ):
+        if url:
+            mock_vertex_call(
+                self.httpx_mock,
+                json,
+                model,
+                parts,
+                usage=usage,
+                publisher=publisher,
+                url=url,
+                status_code=status_code,
+                latency=latency,
+            )
+            return
+
         if not regions:
             regions = os.environ.get("GOOGLE_VERTEX_AI_LOCATION", "us-central1").split(",")
 

--- a/api/tests/integration/common.py
+++ b/api/tests/integration/common.py
@@ -834,13 +834,14 @@ class IntegrationTestClient:
         private_fields: list[str] | None = None,
         autowait: bool = True,
         tenant: str = "_",
+        provider: str | None = None,
     ) -> dict[str, Any]:
         try:
             return await run_task_v1(
                 self.int_api_client,
                 _task_id(task),
                 _schema_id(task),
-                version,
+                version if version else ({"model": model, "provider": provider} if provider and model else None),
                 model.value if isinstance(model, Model) else model,
                 task_input,
                 tenant,

--- a/api/tests/integration/run/gemini_test.py
+++ b/api/tests/integration/run/gemini_test.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_httpx import IteratorStream
 
 from core.domain.models import Model
+from core.domain.models.providers import Provider
 from tests.integration.common import (
     IntegrationTestClient,
     mock_gemini_call,
@@ -77,7 +78,7 @@ async def test_prompt_cached_tokens(test_client: IntegrationTestClient):
         },
     )
 
-    run = await test_client.run_task_v1(task, model=Model.GEMINI_2_5_PRO_PREVIEW_0506)
+    run = await test_client.run_task_v1(task, model=Model.GEMINI_2_5_PRO_PREVIEW_0506, provider=Provider.GOOGLE_GEMINI)
 
     assert run["cost_usd"] == approx(
         (250 * 1.25 / 1_000_000) + (750 * 0.25 * 1.25 / 1_000_000) + (2_000 * 10 / 1_000_000),

--- a/api/tests/integration/run/gemini_test.py
+++ b/api/tests/integration/run/gemini_test.py
@@ -6,8 +6,9 @@ from pytest_httpx import IteratorStream
 from core.domain.models import Model
 from tests.integration.common import (
     IntegrationTestClient,
+    mock_gemini_call,
 )
-from tests.utils import fixture_bytes, fixtures_json
+from tests.utils import approx, fixture_bytes, fixtures_json
 
 
 @pytest.mark.skip(reason="Google no longer returns the thinking mode")
@@ -59,4 +60,25 @@ async def test_thinking_mode_model(test_client: IntegrationTestClient):
     assert (
         run["reasoning_steps"][0]["step"]
         == 'My thinking process for generating the explanation of how AI works went something like this:\n\n1. **Deconstruct the Request:** The user asked "Explain how AI works." This is a broad question, so a comprehensive yet accessible explanation is needed. I need to cover the core principles without getting bogged down in overly technical jargon.\n\n2. **Identify Key Concepts:**  I immediately thought of the fundamental building blocks of AI. This led to the identification of:\n'
+    )
+
+
+async def test_prompt_cached_tokens(test_client: IntegrationTestClient):
+    """Check that price is calculated correctly for cached tokens"""
+    task = await test_client.create_task()
+
+    mock_gemini_call(
+        httpx_mock=test_client.httpx_mock,
+        model=Model.GEMINI_2_5_PRO_PREVIEW_0506,
+        usage={
+            "promptTokenCount": 1_000,
+            "candidatesTokenCount": 2_000,
+            "cachedContentTokenCount": 750,
+        },
+    )
+
+    run = await test_client.run_task_v1(task, model=Model.GEMINI_2_5_PRO_PREVIEW_0506)
+
+    assert run["cost_usd"] == approx(
+        (250 * 1.25 / 1_000_000) + (750 * 0.25 * 1.25 / 1_000_000) + (2_000 * 10 / 1_000_000),
     )


### PR DESCRIPTION
Also add gemini 2.5 preview through vertex with the global endpoint to increase rate limits
ref https://linear.app/workflowai/issue/WOR-4609/prompt-caching-on-gemini-25