### PR TITLE
Landing page banner: "WorkflowAI for Developers"

### DIFF
--- a/client/src/app/landing/LandingPage.tsx
+++ b/client/src/app/landing/LandingPage.tsx
@@ -69,9 +69,7 @@ export function LandingPage() {
 
   return (
     <div className='flex flex-col w-full h-full'>
-      <DeveloperBanner
-        customLink="https://docs.workflowai.com/"
-      />
+      <DeveloperBanner customLink='https://docs.workflowai.com/' />
       {!!modelsToAdvertise && (
         <ModelBanner models={modelsToAdvertise} onClose={dismiss} routeForSignUp={routeForSignUp} />
       )}

--- a/client/src/app/landing/LandingPage.tsx
+++ b/client/src/app/landing/LandingPage.tsx
@@ -9,6 +9,7 @@ import { signUpRoute } from '@/lib/routeFormatter';
 import { useOrFetchUptime } from '@/store/fetchers';
 import { ModelBanner } from '../[tenant]/components/ModelBanner';
 import { useModelToAdvertise } from '../[tenant]/components/useModelToAdvertise';
+import { DeveloperBanner } from './components/DeveloperBanner';
 import { LandingPageContainer } from './container/LandingPageContainer';
 import { CompaniesMoneyComponent } from './sections/Components/CompaniesMoneyComponent';
 import { ComparePriceComponent } from './sections/Components/ComparePriceComponent';
@@ -68,6 +69,9 @@ export function LandingPage() {
 
   return (
     <div className='flex flex-col w-full h-full'>
+      <DeveloperBanner
+        customLink="https://docs.workflowai.com/"
+      />
       {!!modelsToAdvertise && (
         <ModelBanner models={modelsToAdvertise} onClose={dismiss} routeForSignUp={routeForSignUp} />
       )}

--- a/client/src/app/landing/components/DeveloperBanner.tsx
+++ b/client/src/app/landing/components/DeveloperBanner.tsx
@@ -12,7 +12,10 @@ export function DeveloperBanner(props: DeveloperBannerProps) {
     <div className='flex w-full h-9 bg-indigo-500 text-white justify-between items-center px-4 flex-shrink-0'>
       <div />
       <div className='flex flex-row gap-2 items-center'>
-        <span className='text-white text-[13px] font-medium'>Introducing WorkflowAI for Developers!</span>
+        <span className='text-white text-[13px] font-normal'>
+          <span className='font-semibold'>Introducing WorkflowAI for Developers:</span> Bring the benefits of WorkflowAI
+          to your existing agents with just 2 lines of code.
+        </span>
         {customLink && (
           <Link href={customLink} className='text-white text-[13px] font-medium underline'>
             {linkText}

--- a/client/src/app/landing/components/DeveloperBanner.tsx
+++ b/client/src/app/landing/components/DeveloperBanner.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+type DeveloperBannerProps = {
+  customLink?: string;
+  linkText?: string;
+};
+
+export function DeveloperBanner(props: DeveloperBannerProps) {
+  const { customLink, linkText = 'Learn more' } = props;
+
+  return (
+    <div className='flex w-full h-9 bg-indigo-500 text-white justify-between items-center px-4 flex-shrink-0'>
+      <div />
+      <div className='flex flex-row gap-2 items-center'>
+        <span className='text-white text-[13px] font-medium'>
+          Introducing WorkflowAI for Developers!
+        </span>
+        {customLink && (
+          <Link href={customLink} className='text-white text-[13px] font-medium underline'>
+            {linkText}
+          </Link>
+        )}
+      </div>
+      <div />
+    </div>
+  );
+}

--- a/client/src/app/landing/components/DeveloperBanner.tsx
+++ b/client/src/app/landing/components/DeveloperBanner.tsx
@@ -12,9 +12,7 @@ export function DeveloperBanner(props: DeveloperBannerProps) {
     <div className='flex w-full h-9 bg-indigo-500 text-white justify-between items-center px-4 flex-shrink-0'>
       <div />
       <div className='flex flex-row gap-2 items-center'>
-        <span className='text-white text-[13px] font-medium'>
-          Introducing WorkflowAI for Developers!
-        </span>
+        <span className='text-white text-[13px] font-medium'>Introducing WorkflowAI for Developers!</span>
         {customLink && (
           <Link href={customLink} className='text-white text-[13px] font-medium underline'>
             {linkText}


### PR DESCRIPTION
> @Anya will work on adding a banner on workflowai.com that will announce the new features and point to our documentation

Perhaps I took the wording too literally, but read this as saying I should actually add the banner in code, so I did!

Leaving as a draft for now, as docs URL is temporary pending new documentation page

![CleanShot 2025-05-19 at 16 42 24@2x](https://github.com/user-attachments/assets/b8caddb8-1b00-409a-a1f3-c8c8e6f64c93)
