### PR TITLE
fix: handle errors with input variables and deployments

### DIFF
--- a/api/api/routers/agents_v1.py
+++ b/api/api/routers/agents_v1.py
@@ -9,12 +9,13 @@ from api.dependencies.event_router import EventRouterDep
 from api.dependencies.security import RequiredUserOrganizationDep
 from api.dependencies.services import AnalyticsServiceDep
 from api.dependencies.storage import StorageDep
+from api.services.messages.messages_utils import json_schema_for_template
 from api.tags import RouteTags
 from core.domain.analytics_events.analytics_events import CreatedTaskProperties, TaskProperties
 from core.domain.errors import BadRequestError
 from core.domain.events import TaskSchemaCreatedEvent
 from core.domain.fields.chat_message import ChatMessage
-from core.domain.message import Message, Messages
+from core.domain.message import Message
 from core.domain.page import Page
 from core.domain.task_io import SerializableTaskIO
 from core.domain.task_variant import SerializableTaskVariant
@@ -164,20 +165,27 @@ class ExtractTemplateRequest(BaseModel):
     template: str | None = None
     messages: list[Message] | None = None
 
+    base_schema: dict[str, Any] | None = None
+
 
 class ExtractTemplateResponse(BaseModel):
-    json_schema: Mapping[str, Any]
+    json_schema: Mapping[str, Any] | None
+    last_templated_index: int
 
 
 @router.post("/{agent_id}/templates/extract")
 async def extract_template(request: ExtractTemplateRequest) -> ExtractTemplateResponse:
     try:
         if request.template:
-            json_schema = extract_variable_schema(request.template)
+            json_schema, is_templated = extract_variable_schema(request.template)
+            last_templated_index = 0 if is_templated else -1
         elif request.messages:
-            json_schema = Messages(messages=request.messages).json_schema_for_template(base_schema=None)
+            json_schema, last_templated_index = json_schema_for_template(
+                request.messages,
+                base_schema=request.base_schema,
+            )
         else:
             raise BadRequestError("Either template or messages must be provided")
     except InvalidTemplateError as e:
         raise BadRequestError(e.message)
-    return ExtractTemplateResponse(json_schema=json_schema)
+    return ExtractTemplateResponse(json_schema=json_schema, last_templated_index=last_templated_index)

--- a/api/api/routers/openai_proxy/_openai_proxy_handler_test.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler_test.py
@@ -19,6 +19,7 @@ from core.domain.errors import BadRequestError
 from core.domain.message import Message, MessageRole, Messages
 from core.domain.models.models import Model
 from core.domain.task_group_properties import TaskGroupProperties
+from core.domain.task_io import RawMessagesSchema
 from core.domain.tenant_data import PublicOrganizationData
 from core.domain.tool import Tool
 from core.domain.version_environment import VersionEnvironment
@@ -58,6 +59,7 @@ class TestPrepareRun:
     ):
         """Check that the tools are overriden when provided in the completion request"""
 
+        completion_request.input = None
         completion_request.model = "my-agent/#1/production"
         completion_request.tools = [
             OpenAIProxyTool(
@@ -77,8 +79,7 @@ class TestPrepareRun:
             ),
         )
         mock_storage.task_version_resource_by_id.return_value = test_models.task_variant(
-            input_schema={},
-            output_schema={},
+            input_io=RawMessagesSchema,
         )
         result = await proxy_handler._prepare_run(completion_request, PublicOrganizationData())
         assert result.properties.enabled_tools == [

--- a/api/api/services/messages/messages_utils.py
+++ b/api/api/services/messages/messages_utils.py
@@ -1,0 +1,41 @@
+from typing import Any, Iterable
+
+from core.domain.message import Message
+from core.utils.schema_sanitation import streamline_schema
+from core.utils.templates import extract_variable_schema
+
+
+def json_schema_for_template(
+    messages: Iterable[Message],
+    base_schema: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, int]:
+    """Returns a json schema for template variables present in the messages and the index
+    of the last templated message"""
+
+    # TODO: handle files as strings in templates
+    # var_regexp = re.compile(r"\{\{([^}]+)\}\}")
+
+    # files: dict[str, FileKind | str] = {}
+    schema: dict[str, Any] | None = None
+    last_templated_index = -1
+    for i, m in enumerate(messages):
+        # If format is not provided, then we treat as a plain string
+        # if not format:
+        #     templatable_parts.append(m)
+        #     continue
+        # # If format is provided and the whole content is a variable
+        # if match := var_regexp.match(m):
+        #     files[match.group(1)] = format
+        #     continue
+        # We are in a case where the content is a mix of variables and plain text so we can't
+        # really extract the file
+        for c, _ in m.content_iterator():
+            schema, is_templated = extract_variable_schema(c, start_schema=schema, use_types_from=base_schema)
+            if is_templated:
+                last_templated_index = i
+
+    # for var, kind in files.items():
+    #     # We just add the format here
+    #     # It will be streamlined and replace with the proper
+    #     schema.setdefault("properties", {})[var] = {"$ref": "#/$defs/File", "format": kind}
+    return streamline_schema(schema) if schema else None, last_templated_index

--- a/api/api/services/messages/messages_utils_test.py
+++ b/api/api/services/messages/messages_utils_test.py
@@ -1,0 +1,106 @@
+from api.services.messages.messages_utils import json_schema_for_template
+from core.domain.message import Message
+
+
+class TestJsonSchemaForTemplate:
+    def test_empty_messages(self):
+        """Test with empty messages list."""
+        messages: list[Message] = []
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema is None
+        assert last_index == -1
+
+    def test_no_templated_messages(self):
+        """Test with messages containing no template variables."""
+        messages = [
+            Message.with_text("Hello world"),
+            Message.with_text("This is a test"),
+        ]
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema is None
+        assert last_index == -1
+
+    def test_single_templated_message(self):
+        """Test with a single message containing template variables."""
+        messages = [
+            Message.with_text("Hello {{name}}"),
+        ]
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema is not None
+        assert "properties" in schema
+        assert "name" in schema["properties"]
+        assert last_index == 0
+
+    def test_multiple_templated_messages(self):
+        """Test with multiple messages containing template variables."""
+        messages = [
+            Message.with_text("Hello {{name}}"),
+            Message.with_text("Your age is {{age}}"),
+            Message.with_text("Welcome to {{city}}"),
+        ]
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema == {
+            "type": "object",
+            "properties": {
+                "name": {},
+                "age": {},
+                "city": {},
+            },
+        }
+        assert last_index == 2
+
+    def test_with_base_schema(self):
+        """Test with a provided base schema."""
+        messages = [
+            Message.with_text("Hello {{name}}"),
+        ]
+        base_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+            },
+        }
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema == {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+            },
+        }
+        assert last_index == 0
+
+    def test_mixed_content_messages(self):
+        """Test with messages containing both templated and non-templated content."""
+        messages = [
+            Message.with_text("Hello world"),
+            Message.with_text("Welcome {{name}}"),
+            Message.with_text("This is a test"),
+            Message.with_text("Your age is {{age}}"),
+        ]
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema is not None
+        assert "properties" in schema
+        assert "name" in schema["properties"]
+        assert "age" in schema["properties"]
+        assert last_index == 3
+
+    def test_complex_template_variables(self):
+        """Test with complex template variable patterns."""
+        messages = [
+            Message.with_text("User: {{user.name}}"),
+            Message.with_text("Address: {{user.address.street}}"),
+        ]
+        base_schema = None
+        schema, last_index = json_schema_for_template(messages, base_schema)
+        assert schema is not None
+        assert "properties" in schema
+        assert "user" in schema["properties"]
+        assert "properties" in schema["properties"]["user"]
+        assert "name" in schema["properties"]["user"]["properties"]
+        assert "address" in schema["properties"]["user"]["properties"]
+        assert last_index == 1

--- a/api/api/services/messages/messages_utils_test.py
+++ b/api/api/services/messages/messages_utils_test.py
@@ -104,3 +104,59 @@ class TestJsonSchemaForTemplate:
         assert "name" in schema["properties"]["user"]["properties"]
         assert "address" in schema["properties"]["user"]["properties"]
         assert last_index == 1
+
+    def test_string_only(self):
+        messages = [Message.with_text("Hello, {{ name }}!")]
+        schema, last_index = json_schema_for_template(messages, base_schema=None)
+        assert schema == {
+            "type": "object",
+            "properties": {"name": {}},
+        }
+        assert last_index == 0
+
+    # @pytest.mark.skip(reason="TODO: Add image support")
+    # def test_file_only(self):
+    #     messages = Messages(
+    #         messages=[Message(role="user", content=[MessageContent(file=File(url="{{a_file_url}}"))])],
+    #     )
+    #     schema = messages.json_schema_for_template(base_schema=None)
+    #     assert schema == {
+    #         "$defs": {"File": mock.ANY},
+    #         "type": "object",
+    #         "properties": {"a_file_url": {"$ref": "#/$defs/File"}},
+    #     }
+
+    # @pytest.mark.skip(reason="TODO: Add image support")
+    # def test_file_and_text(self):
+    #     messages = Messages(
+    #         messages=[
+    #             Message(
+    #                 role="user",
+    #                 content=[
+    #                     MessageContent(text="Hello, {{ name }}!"),
+    #                     MessageContent(file=File(url="{{a_file_url}}")),
+    #                 ],
+    #             ),
+    #         ],
+    #     )
+    #     schema = messages.json_schema_for_template(base_schema=None)
+    #     assert schema == {
+    #         "$defs": {"File": mock.ANY},
+    #         "type": "object",
+    #         "properties": {
+    #             "name": {},
+    #             "a_file_url": {"$ref": "#/$defs/File"},
+    #         },
+    #     }
+
+    # @pytest.mark.skip(reason="TODO: Add image support")
+    # def test_image_url(self):
+    #     messages = Messages(
+    #         messages=[Message(role="user", content=[MessageContent(file=File(url="{{a_file_url}}", format="image"))])],
+    #     )
+    #     schema = messages.json_schema_for_template(base_schema=None)
+    #     assert schema == {
+    #         "$defs": {"Image": mock.ANY},
+    #         "type": "object",
+    #         "properties": {"a_file_url": {"$ref": "#/$defs/Image"}},
+    #     }

--- a/api/core/domain/message.py
+++ b/api/core/domain/message.py
@@ -3,8 +3,9 @@ from collections.abc import Iterator, Sequence
 from enum import StrEnum, auto
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel, Field
 
+from core.domain.consts import INPUT_KEY_MESSAGES
 from core.domain.fields.file import File, FileKind, FileWithKeyPath
 from core.domain.fields.image_options import ImageOptions
 from core.domain.tool_call import ToolCall, ToolCallRequestWithID
@@ -120,7 +121,7 @@ class Message(BaseModel):
 
 
 class Messages(BaseModel):
-    messages: list[Message]
+    messages: list[Message] = Field(validation_alias=AliasChoices("messages", INPUT_KEY_MESSAGES))
 
     async def templated(self, renderer: TemplateRenderer):
         try:

--- a/api/core/domain/message_test.py
+++ b/api/core/domain/message_test.py
@@ -1,9 +1,7 @@
-from unittest import mock
-
 import pytest
 
 from core.domain.fields.file import File
-from core.domain.message import Message, MessageContent, Messages
+from core.domain.message import Message, MessageContent
 from core.utils.templates import InvalidTemplateError, TemplateManager
 
 
@@ -45,60 +43,3 @@ class TestMessage:
 
         # Check that no field is unset
         assert templated.model_fields_set == set(Message.model_fields.keys())
-
-
-class TestJsonSchemaForTemplate:
-    def test_string_only(self):
-        messages = Messages(messages=[Message.with_text("Hello, {{ name }}!")])
-        schema = messages.json_schema_for_template(base_schema=None)
-        assert schema == {
-            "type": "object",
-            "properties": {"name": {}},
-        }
-
-    @pytest.mark.skip(reason="TODO: Add image support")
-    def test_file_only(self):
-        messages = Messages(
-            messages=[Message(role="user", content=[MessageContent(file=File(url="{{a_file_url}}"))])],
-        )
-        schema = messages.json_schema_for_template(base_schema=None)
-        assert schema == {
-            "$defs": {"File": mock.ANY},
-            "type": "object",
-            "properties": {"a_file_url": {"$ref": "#/$defs/File"}},
-        }
-
-    @pytest.mark.skip(reason="TODO: Add image support")
-    def test_file_and_text(self):
-        messages = Messages(
-            messages=[
-                Message(
-                    role="user",
-                    content=[
-                        MessageContent(text="Hello, {{ name }}!"),
-                        MessageContent(file=File(url="{{a_file_url}}")),
-                    ],
-                ),
-            ],
-        )
-        schema = messages.json_schema_for_template(base_schema=None)
-        assert schema == {
-            "$defs": {"File": mock.ANY},
-            "type": "object",
-            "properties": {
-                "name": {},
-                "a_file_url": {"$ref": "#/$defs/File"},
-            },
-        }
-
-    @pytest.mark.skip(reason="TODO: Add image support")
-    def test_image_url(self):
-        messages = Messages(
-            messages=[Message(role="user", content=[MessageContent(file=File(url="{{a_file_url}}", format="image"))])],
-        )
-        schema = messages.json_schema_for_template(base_schema=None)
-        assert schema == {
-            "$defs": {"Image": mock.ANY},
-            "type": "object",
-            "properties": {"a_file_url": {"$ref": "#/$defs/Image"}},
-        }

--- a/api/core/runners/workflowai/workflowai_runner.py
+++ b/api/core/runners/workflowai/workflowai_runner.py
@@ -563,10 +563,13 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
             if isinstance(input, list):
                 input = {"messages": input}
             try:
-                return Messages.model_validate(input)
+                messages = Messages.model_validate(input)
             except ValidationError as e:
                 # Capturing for now just in case
                 raise BadRequestError(f"Input is not a valid list of messages: {str(e)}", capture=True) from e
+            if self._options.messages:
+                messages.messages = [*self._options.messages, *messages.messages]
+            return messages
         if not self._options.messages:
             return None
         # Then the current version is a full message template

--- a/api/tests/integration/openai_proxy/common.py
+++ b/api/tests/integration/openai_proxy/common.py
@@ -1,0 +1,25 @@
+from openai.types.chat import ChatCompletion
+
+from tests.integration.common import IntegrationTestClient
+
+
+async def fetch_run_from_completion(test_client: IntegrationTestClient, completion: ChatCompletion):
+    task_id, run_id = completion.id.split("/")
+    return await test_client.fetch_run({"id": task_id}, run_id=run_id, v1=True)
+
+
+async def save_version_from_completion(
+    test_client: IntegrationTestClient,
+    completion: ChatCompletion,
+    deploy_to: str | None = None,
+):
+    task_id, run_id = completion.id.split("/")
+    created = await test_client.post(f"/v1/_/agents/{task_id}/runs/{run_id}/version/save")
+
+    if deploy_to:
+        await test_client.post(
+            f"/v1/_/agents/{task_id}/versions/{created['id']}/deploy",
+            json={"environment": deploy_to},
+        )
+
+    return await test_client.fetch_version({"id": task_id}, created["id"])

--- a/api/tests/integration/openai_proxy/openai_proxy_errors_test.py
+++ b/api/tests/integration/openai_proxy/openai_proxy_errors_test.py
@@ -1,0 +1,43 @@
+import pytest
+from openai import AsyncOpenAI, BadRequestError
+
+from tests.integration.common import IntegrationTestClient
+from tests.integration.openai_proxy.common import save_version_from_completion
+
+
+async def test_deployment_with_no_input_variables(
+    test_client: IntegrationTestClient,
+    openai_client: AsyncOpenAI,
+):
+    """Check the error when a user triggers a deployment with no input variables but
+    passes input variables"""
+
+    test_client.mock_openai_call(raw_content="Hello James!")
+
+    res = await openai_client.chat.completions.create(
+        model="my-agent/gpt-4o",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+    )
+    assert res.choices[0].message.content == "Hello James!"
+    await test_client.wait_for_completed_tasks()
+
+    # Created version will have no input variables
+    version = await save_version_from_completion(test_client, res, "production")
+    assert "messages" not in version["properties"]
+
+    # Re-running with the same messages should work
+    test_client.mock_openai_call(raw_content="Hello John!")
+    res = await openai_client.chat.completions.create(
+        model="my-agent/#1/production",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+    )
+    assert res.choices[0].message.content == "Hello John!"
+
+    # If we try and re-run with input variables we should get a bad request
+    with pytest.raises(BadRequestError) as e:
+        res = await openai_client.chat.completions.create(
+            model="my-agent/#1/production",
+            messages=[{"role": "user", "content": "Hello, world!"}],
+            extra_body={"input": {"name": "John"}},
+        )
+    assert "The deployment you are trying to use does not contain any messages" in str(e.value)

--- a/api/tests/integration/openai_proxy/openai_proxy_test.py
+++ b/api/tests/integration/openai_proxy/openai_proxy_test.py
@@ -8,6 +8,7 @@ from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMe
 
 from core.domain.models.models import Model
 from tests.integration.common import IntegrationTestClient
+from tests.integration.openai_proxy.common import save_version_from_completion
 
 
 async def test_raw_string_output(test_client: IntegrationTestClient, openai_client: AsyncOpenAI):
@@ -504,3 +505,78 @@ async def test_unsupported_parameter(openai_client: AsyncOpenAI):
         )
 
     assert "Fields `logit_bias`, `stop` are not supported" in str(e)
+
+
+async def test_deployed_version_no_messages(test_client: IntegrationTestClient, openai_client: AsyncOpenAI):
+    test_client.mock_openai_call(raw_content="Hello James!")
+
+    # Create a version that will result in empty messages in the version
+    res = await openai_client.chat.completions.create(
+        model="my-agent/gpt-4o",
+        messages=[
+            {"role": "user", "content": "Hello, world!"},
+        ],
+    )
+    assert res.choices[0].message.content == "Hello James!"
+    await test_client.wait_for_completed_tasks()
+
+    version = await save_version_from_completion(test_client, res, "production")
+    assert version["properties"].get("messages") is None
+
+    # Now use the deployed version
+    test_client.mock_openai_call(raw_content="Hello James!")
+
+    res = await openai_client.chat.completions.create(
+        model="my-agent/#1/production",
+        messages=[{"role": "user", "content": "Hello hades!"}],
+    )
+    assert res.choices[0].message.content == "Hello James!"
+
+    request = test_client.httpx_mock.get_requests(url="https://api.openai.com/v1/chat/completions")
+    assert len(request) == 2, "sanity"
+
+    body = json.loads(request[-1].content)
+    assert len(body["messages"]) == 1
+    assert body["messages"][0]["content"] == "Hello hades!"
+
+
+async def test_deployed_version_no_messages_with_empty_input(
+    test_client: IntegrationTestClient,
+    openai_client: AsyncOpenAI,
+):
+    test_client.mock_openai_call(raw_content="Hello James!")
+
+    # Create a version that will result in empty messages in the version
+    res = await openai_client.chat.completions.create(
+        model="my-agent/gpt-4o",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello, world!"},
+        ],
+        # Passing an empty input signals that the first system message should be used in the version
+        extra_body={"input": {}},
+    )
+    assert res.choices[0].message.content == "Hello James!"
+    await test_client.wait_for_completed_tasks()
+
+    version = await save_version_from_completion(test_client, res, "production")
+    assert version["properties"].get("messages") == [
+        {"role": "system", "content": [{"text": "You are a helpful assistant"}]},
+    ]
+
+    # Now use the deployed version
+    test_client.mock_openai_call(raw_content="Hello James!")
+
+    res = await openai_client.chat.completions.create(
+        model="my-agent/#1/production",
+        messages=[{"role": "user", "content": "Hello hades!"}],
+    )
+    assert res.choices[0].message.content == "Hello James!"
+
+    request = test_client.httpx_mock.get_requests(url="https://api.openai.com/v1/chat/completions")
+    assert len(request) == 2, "sanity"
+
+    body = json.loads(request[-1].content)
+    assert len(body["messages"]) == 2
+    assert body["messages"][0]["content"] == "You are a helpful assistant"
+    assert body["messages"][1]["content"] == "Hello hades!"

--- a/api/tests/models.py
+++ b/api/tests/models.py
@@ -86,7 +86,9 @@ def task_example_ser(**kwargs: Any) -> SerializableTaskExample:
 
 def task_variant(
     input_schema: dict[str, Any] | None = None,
+    input_io: SerializableTaskIO | None = None,
     output_schema: dict[str, Any] | None = None,
+    output_io: SerializableTaskIO | None = None,
     input_model: type[BaseModel] | None = None,
     output_model: type[BaseModel] | None = None,
     **kwargs: Any,
@@ -96,14 +98,17 @@ def task_variant(
         task_id="task_id",
         name="task_name",
         task_schema_id=1,
-        input_schema=SerializableTaskIO.from_model(input_model)
-        if input_model
-        else SerializableTaskIO(
-            version="input_version",
-            json_schema=input_schema
-            or {"type": "object", "properties": {"input": {"type": "string"}}, "required": ["input"]},
+        input_schema=input_io
+        or (
+            SerializableTaskIO.from_model(input_model)
+            if input_model
+            else SerializableTaskIO(
+                version="input_version",
+                json_schema=input_schema
+                or {"type": "object", "properties": {"input": {"type": "string"}}, "required": ["input"]},
+            )
         ),
-        output_schema=SerializableTaskIO.from_model(output_model)
+        output_schema=output_io or SerializableTaskIO.from_model(output_model)
         if output_model
         else SerializableTaskIO(
             version="output_version",


### PR DESCRIPTION
ref https://linear.app/workflowai/issue/WOR-4702/better-error-message-when-an-input-is-passed-to-a-schema-that-does-not

ref https://linear.app/workflowai/issue/WOR-4711/what-happens-when-saving-a-version-without-variables

ref https://linear.app/workflowai/issue/WOR-4681/avoid-saving-non-templated-messages-in-the-version-by-default