### PR TITLE
Add sortable columns to agents table

### DIFF
--- a/client/src/app/[tenant]/agents/tasks/TasksTable.tsx
+++ b/client/src/app/[tenant]/agents/tasks/TasksTable.tsx
@@ -3,6 +3,7 @@ import { TenantID } from '@/types/aliases';
 import { SerializableTask } from '@/types/workflowAI';
 import { TaskRowContainer } from './TaskRow';
 import { TasksTableHeaders } from './TasksTableHeaders';
+import { TasksSortKey } from './utils';
 
 type TasksTableProps = {
   tenant: TenantID;
@@ -11,13 +12,14 @@ type TasksTableProps = {
   onViewRuns: (task: SerializableTask) => void;
   onViewCode: (task: SerializableTask) => void;
   onViewDeployments: (task: SerializableTask) => void;
+  onSortModeChange: (mode: TasksSortKey) => void;
 };
 
 export function TasksTable(props: TasksTableProps) {
-  const { tasks, onTryInPlayground, onViewRuns, onViewCode, onViewDeployments, tenant } = props;
+  const { tasks, onTryInPlayground, onViewRuns, onViewCode, onViewDeployments, tenant, onSortModeChange } = props;
 
   return (
-    <TableView headers={<TasksTableHeaders />}>
+    <TableView headers={<TasksTableHeaders onSortModeChange={onSortModeChange} />}>
       {tasks.map((task) => (
         <TaskRowContainer
           tenant={tenant}

--- a/client/src/app/[tenant]/agents/tasks/TasksTableHeaders.tsx
+++ b/client/src/app/[tenant]/agents/tasks/TasksTableHeaders.tsx
@@ -1,11 +1,25 @@
 import { TableViewHeaderEntry } from '@/components/ui/TableView';
+import { TasksSortKey } from './utils';
 
-export function TasksTableHeaders() {
+type TasksTableHeadersProps = {
+  onSortModeChange: (mode: TasksSortKey) => void;
+};
+
+export function TasksTableHeaders(props: TasksTableHeadersProps) {
+  const { onSortModeChange } = props;
   return (
     <>
       <TableViewHeaderEntry title='AI agent' className='pl-2 flex-1' />
-      <TableViewHeaderEntry title='Runs in last 7d' className='w-[100px]' />
-      <TableViewHeaderEntry title='Cost' className='w-[57px]' />
+      <TableViewHeaderEntry
+        title='Runs in last 7d'
+        className='w-[100px]'
+        onClick={() => onSortModeChange(TasksSortKey.Runs)}
+      />
+      <TableViewHeaderEntry
+        title='Cost'
+        className='w-[57px]'
+        onClick={() => onSortModeChange(TasksSortKey.Cost)}
+      />
     </>
   );
 }

--- a/client/src/app/[tenant]/agents/tasks/utils.tsx
+++ b/client/src/app/[tenant]/agents/tasks/utils.tsx
@@ -1,5 +1,10 @@
 import { filterActiveTasksIDs } from '@/lib/taskUtils';
-import { SerializableTask } from '@/types/workflowAI';
+import { AgentStat, SerializableTask } from '@/types/workflowAI';
+
+export enum TasksSortKey {
+  Runs = 'runs',
+  Cost = 'cost',
+}
 
 export function filterTasks(tasks: SerializableTask[], searchQuery: string) {
   // If search query is empty, return all tasks
@@ -57,4 +62,31 @@ export function sortTasks(tasks: SerializableTask[]) {
     const bName = b.name.length === 0 ? b.id : b.name;
     return aName.localeCompare(bName);
   });
+}
+
+export function sortTasksByStats(
+  tasks: SerializableTask[],
+  stats: Map<number, AgentStat> | undefined,
+  sortKey: TasksSortKey,
+  revertOrder: boolean
+) {
+  const sorted = tasks
+    .slice()
+    .sort((a, b) => {
+      const aStat = stats?.get(a.uid);
+      const bStat = stats?.get(b.uid);
+
+      const aValue =
+        sortKey === TasksSortKey.Runs
+          ? aStat?.run_count ?? 0
+          : aStat?.total_cost_usd ?? 0;
+      const bValue =
+        sortKey === TasksSortKey.Runs
+          ? bStat?.run_count ?? 0
+          : bStat?.total_cost_usd ?? 0;
+
+      return bValue - aValue;
+    });
+
+  return revertOrder ? sorted.reverse() : sorted;
 }

--- a/client/src/app/[tenant]/agents/tasks/utils.tsx
+++ b/client/src/app/[tenant]/agents/tasks/utils.tsx
@@ -33,7 +33,7 @@ export function filterTasks(tasks: SerializableTask[], searchQuery: string) {
 export function sortTasks(tasks: SerializableTask[]) {
   const activeTasksIds = filterActiveTasksIDs(tasks);
 
-  return tasks.sort((a, b) => {
+  return tasks.toSorted((a, b) => {
     // First priority: run_count
     if (!!a.run_count && !!b.run_count) {
       return b.run_count - a.run_count;
@@ -70,9 +70,7 @@ export function sortTasksByStats(
   sortKey: TasksSortKey,
   revertOrder: boolean
 ) {
-  const sorted = tasks
-    .slice()
-    .sort((a, b) => {
+  const sorted = tasks.toSorted((a, b) => {
       const aStat = stats?.get(a.uid);
       const bStat = stats?.get(b.uid);
 


### PR DESCRIPTION
## Summary
- add sort key enum and function to sort by stats
- make task header clickable
- wire sorting state into tasks table and container

## Testing
- `yarn lint` *(fails: Request was cancelled)*
- `yarn test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68408ce14800832180bd2302c2dea407