### PR TITLE
Add Cerebras provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -210,6 +210,12 @@ WORKFLOWAI_JWK=eyJrdHkiOiJFQyIsIngiOiJLVUpZYzd2V0R4Um55NW5BdC1VNGI4MHRoQ1ZuaERUT
 # Get your Fireworks API key from https://fireworks.ai/account/api-keys
 # FIREWORKS_API_KEY=
 
+# Cerebras
+# Get your Cerebras API key from https://cerebras.ai
+# CEREBRAS_API_KEY=
+# CEREBRAS_API_URL=https://api.cerebras.ai/v1/chat/completions
+# CEREBRAS_MODELS_URL=https://api.cerebras.ai/v1/models
+
 # CSM Features
 # HELPSCOUT_CLIENT_ID=
 # HELPSCOUT_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 https://github.com/user-attachments/assets/febf1047-ed85-4af0-b796-5242aef051b4
 
-- **Model-agnostic**: Works with all major AI models including OpenAI, Anthropic, Claude, Google/Gemini, Mistral, DeepSeek, Grok with a unified interface that makes switching between providers seamless. [View all 80+ supported models](https://workflowai.com/docs/agents/flight-info-extractor/1).
+- **Model-agnostic**: Works with all major AI models including OpenAI, Anthropic, Claude, Google/Gemini, Mistral, DeepSeek, Grok, Cerebras with a unified interface that makes switching between providers seamless. [View all 80+ supported models](https://workflowai.com/docs/agents/flight-info-extractor/1).
 
 ![Model-agnostic](https://github.com/user-attachments/assets/fa9ba9bb-4eed-422a-93c0-ccfc02dcdc86)
 
@@ -185,7 +185,7 @@ The [client](./client/README.md) is a NextJS app that serves as a frontend
 
 ### Setting up providers
 
-WorkflowAI supports a variety of LLM providers (OpenAI, Anthropic, Amazon Bedrock, Azure OpenAI, Grok, Gemini, FireworksAI, ...). View all supported providers [here](https://github.com/WorkflowAI/WorkflowAI/tree/main/api/core/providers).
+WorkflowAI supports a variety of LLM providers (OpenAI, Anthropic, Amazon Bedrock, Azure OpenAI, Grok, Gemini, FireworksAI, Cerebras, ...). View all supported providers [here](https://github.com/WorkflowAI/WorkflowAI/tree/main/api/core/providers).
 
 Each provider has a different set of credentials and configuration. Providers that have the required environment
 variables are loaded by default (see the [sample env](.env.sample) for the available variables). Providers can also be configured per tenant through the UI.

--- a/api/core/domain/models/_displayed_provider.py
+++ b/api/core/domain/models/_displayed_provider.py
@@ -12,3 +12,4 @@ class DisplayedProvider(StrEnum):
     GROQ = "Groq"
     AMAZON_BEDROCK = "Amazon Bedrock"
     X_AI = "xAI"
+    CEREBRAS = "Cerebras"

--- a/api/core/domain/models/model_provider_datas_mapping.py
+++ b/api/core/domain/models/model_provider_datas_mapping.py
@@ -1292,6 +1292,16 @@ XAI_PROVIDER_DATA: ProviderDataByModel = {
             source="https://docs.x.ai/docs/models#models-and-pricing",
         ),
     ),
+} 
+
+CEREBRAS_PROVIDER_DATA: ProviderDataByModel = {
+    Model.LLAMA_3_1_8B: ModelProviderData(
+        text_price=TextPricePerToken(
+            prompt_cost_per_token=0.20 * ONE_MILLION_TH,
+            completion_cost_per_token=0.20 * ONE_MILLION_TH,
+            source="https://www.cerebras.net/pricing",
+        ),
+    ),
 }
 
 GOOGLE_IMAGEN_PROVIDER_DATA: ProviderDataByModel = {
@@ -1363,4 +1373,7 @@ MODEL_PROVIDER_DATAS: ProviderModelDataMapping = {
     # ------------------------------------------------------------------------------------------------
     # XAI
     Provider.X_AI: XAI_PROVIDER_DATA,
+    # ------------------------------------------------------------------------------
+    # Cerebras
+    Provider.CEREBRAS: CEREBRAS_PROVIDER_DATA,
 }

--- a/api/core/domain/models/providers.py
+++ b/api/core/domain/models/providers.py
@@ -21,4 +21,5 @@ class Provider(StrEnum):
     GOOGLE_GEMINI = "google_gemini"
     GOOGLE_IMAGEN = "google_vertex_imagen"
     X_AI = "xai"
+    CEREBRAS = "cerebras"
     OPEN_AI_IMAGE = "openai_image"

--- a/api/core/providers/cerebras/cerebras_domain.py
+++ b/api/core/providers/cerebras/cerebras_domain.py
@@ -1,0 +1,75 @@
+from typing import Any, Literal
+from pydantic import BaseModel, Field
+
+from core.domain.llm_usage import LLMUsage
+from core.domain.message import MessageDeprecated
+from core.providers.base.models import StandardMessage, TextContentDict
+
+CerebrasRole = Literal["system", "user", "assistant"]
+
+
+class CerebrasMessage(BaseModel):
+    role: CerebrasRole
+    content: str | None = None
+
+    @classmethod
+    def from_domain(cls, message: MessageDeprecated) -> "CerebrasMessage":
+        return cls(role=message.role.value, content=message.content)
+
+    def to_standard(self) -> StandardMessage:
+        return StandardMessage(
+            role=self.role,
+            content=[TextContentDict(type="text", text=self.content or "")],
+        )
+
+
+class CompletionRequest(BaseModel):
+    messages: list[CerebrasMessage]
+    model: str
+    temperature: float
+    max_tokens: int | None
+    stream: bool = False
+    top_p: float | None = None
+
+
+class ChoiceMessage(BaseModel):
+    role: CerebrasRole | None = None
+    content: str | None = None
+
+
+class Choice(BaseModel):
+    message: ChoiceMessage
+    finish_reason: str | None = None
+
+
+class Usage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def to_domain(self) -> LLMUsage:
+        return LLMUsage(
+            prompt_token_count=self.prompt_tokens,
+            completion_token_count=self.completion_tokens,
+        )
+
+
+class CompletionResponse(BaseModel):
+    id: str | None = None
+    choices: list[Choice] = Field(default_factory=list)
+    usage: Usage | None = None
+
+
+class DeltaMessage(BaseModel):
+    content: str | None = None
+
+
+class ChoiceDelta(BaseModel):
+    delta: DeltaMessage
+    finish_reason: str | None = None
+
+
+class StreamedResponse(BaseModel):
+    id: str | None = None
+    choices: list[ChoiceDelta] = Field(default_factory=list)
+    usage: Usage | None = None

--- a/api/core/providers/cerebras/cerebras_provider.py
+++ b/api/core/providers/cerebras/cerebras_provider.py
@@ -1,0 +1,149 @@
+from typing import Any, Literal
+
+from httpx import Response
+from pydantic import BaseModel
+from typing_extensions import override
+
+from core.domain.llm_usage import LLMUsage
+from core.domain.message import MessageDeprecated
+from core.domain.models import Model, Provider
+from core.providers.base.abstract_provider import RawCompletion
+from core.providers.base.httpx_provider import HTTPXProvider
+from core.providers.base.models import StandardMessage
+from core.providers.base.provider_error import (
+    FailedGenerationError,
+    MaxTokensExceededError,
+)
+from core.providers.base.provider_options import ProviderOptions
+from core.providers.base.streaming_context import ParsedResponse, ToolCallRequestBuffer
+from core.providers.base.utils import get_provider_config_env
+
+from .cerebras_domain import (
+    CerebrasMessage,
+    CompletionRequest,
+    CompletionResponse,
+    StreamedResponse,
+    Usage,
+)
+
+
+class CerebrasConfig(BaseModel):
+    provider: Literal[Provider.CEREBRAS] = Provider.CEREBRAS
+    api_key: str
+    url: str = "https://api.cerebras.ai/v1/chat/completions"
+    models_url: str = "https://api.cerebras.ai/v1/models"
+
+    def __str__(self):
+        return f"CerebrasConfig(api_key={self.api_key[:4]}****)"
+
+
+class CerebrasProvider(HTTPXProvider[CerebrasConfig, CompletionResponse]):
+    @override
+    @classmethod
+    def name(cls) -> Provider:
+        return Provider.CEREBRAS
+
+    @override
+    @classmethod
+    def required_env_vars(cls) -> list[str]:
+        return ["CEREBRAS_API_KEY"]
+
+    @override
+    @classmethod
+    def standardize_messages(cls, messages: list[dict[str, Any]]) -> list[StandardMessage]:
+        return [CerebrasMessage.model_validate(m).to_standard() for m in messages]
+
+    def model_str(self, model: Model) -> str:
+        return model.value
+
+    @override
+    def _build_request(self, messages: list[MessageDeprecated], options: ProviderOptions, stream: bool) -> BaseModel:
+        return CompletionRequest(
+            messages=[CerebrasMessage.from_domain(m) for m in messages],
+            model=self.model_str(Model(options.model)),
+            temperature=options.temperature,
+            max_tokens=options.max_tokens,
+            stream=stream,
+            top_p=options.top_p,
+        )
+
+    @override
+    async def _request_headers(self, request: dict[str, Any], url: str, model: Model) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._config.api_key}",
+        }
+
+    @override
+    def _request_url(self, model: Model, stream: bool) -> str:
+        return self._config.url
+
+    @override
+    def _response_model_cls(self) -> type[CompletionResponse]:
+        return CompletionResponse
+
+    @override
+    def _extract_content_str(self, response: CompletionResponse) -> str:
+        for choice in response.choices:
+            if choice.finish_reason == "length":
+                raise MaxTokensExceededError(
+                    msg="Model returned a response with a length finish reason, meaning the maximum number of tokens was exceeded.",
+                    raw_completion=response,
+                )
+        message = response.choices[0].message
+        if not message.content:
+            raise FailedGenerationError(
+                msg="Model did not generate a response content",
+                capture=True,
+            )
+        return message.content
+
+    @override
+    def _extract_usage(self, response: CompletionResponse) -> LLMUsage | None:
+        return response.usage.to_domain() if response.usage else None
+
+    @override
+    @classmethod
+    def _default_config(cls, index: int) -> CerebrasConfig:
+        return CerebrasConfig(
+            api_key=get_provider_config_env("CEREBRAS_API_KEY", index),
+            url=get_provider_config_env("CEREBRAS_API_URL", index, "https://api.cerebras.ai/v1/chat/completions"),
+            models_url=get_provider_config_env("CEREBRAS_MODELS_URL", index, "https://api.cerebras.ai/v1/models"),
+        )
+
+    @override
+    def _extract_stream_delta(
+        self,
+        sse_event: bytes,
+        raw_completion: RawCompletion,
+        tool_call_request_buffer: dict[int, ToolCallRequestBuffer],
+    ) -> ParsedResponse:
+        if sse_event == b"[DONE]":
+            return ParsedResponse("")
+        raw = StreamedResponse.model_validate_json(sse_event)
+        if raw.choices:
+            if raw.choices[0].finish_reason == "length":
+                raise MaxTokensExceededError(
+                    msg="Model returned a response with a length finish reason, meaning the maximum number of tokens was exceeded.",
+                    raw_completion=raw,
+                )
+        if raw.usage:
+            raw_completion.usage = raw.usage.to_domain()
+        if raw.choices and raw.choices[0].delta:
+            return ParsedResponse(raw.choices[0].delta.content or "")
+        return ParsedResponse("")
+
+    def default_model(self) -> Model:
+        return Model.LLAMA_3_1_8B
+
+    async def list_models(self) -> list[str]:
+        """Return the list of models supported by the Cerebras API."""
+        async with self._open_client(self._config.models_url) as client:
+            response = await client.get(self._config.models_url)
+            response.raise_for_status()
+            data = response.json()
+            # API returns {"data": [{"id": ...}]} or a plain list
+            if isinstance(data, dict):
+                models = [m.get("id") for m in data.get("data", [])]
+            else:
+                models = [m.get("id") for m in data]
+            return [m for m in models if m]

--- a/api/core/providers/cerebras/cerebras_provider_test.py
+++ b/api/core/providers/cerebras/cerebras_provider_test.py
@@ -1,0 +1,98 @@
+import json
+import unittest
+
+import pytest
+from pytest_httpx import HTTPXMock, IteratorStream
+
+from core.domain.llm_usage import LLMUsage
+from core.domain.message import MessageDeprecated
+from core.domain.models import Model, Provider
+from core.domain.structured_output import StructuredOutput
+from core.providers.base.provider_options import ProviderOptions
+from core.providers.cerebras.cerebras_domain import CompletionResponse, Choice, ChoiceMessage, Usage
+from core.providers.cerebras.cerebras_provider import CerebrasConfig, CerebrasProvider
+
+
+class TestCerebrasProvider(unittest.TestCase):
+    def test_name(self):
+        self.assertEqual(CerebrasProvider.name(), Provider.CEREBRAS)
+
+    def test_required_env_vars(self):
+        self.assertEqual(CerebrasProvider.required_env_vars(), ["CEREBRAS_API_KEY"])
+
+
+@pytest.fixture(scope="function")
+def cerebras_provider():
+    provider = CerebrasProvider(config=CerebrasConfig(api_key="token"))
+    return provider
+
+
+class TestBuildRequest:
+    def test_build_request(self, cerebras_provider: CerebrasProvider):
+        request = cerebras_provider._build_request(  # pyright: ignore [reportPrivateUsage]
+            messages=[MessageDeprecated(role=MessageDeprecated.Role.USER, content="Hi")],
+            options=ProviderOptions(model=Model.LLAMA_3_1_8B, max_tokens=5, temperature=0),
+            stream=False,
+        )
+        dumped = request.model_dump()
+        assert dumped["messages"][0]["role"] == "user"
+        assert dumped["messages"][0]["content"] == "Hi"
+        assert dumped["max_tokens"] == 5
+
+
+class TestComplete:
+    async def test_complete(self, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            url="https://api.cerebras.ai/v1/chat/completions",
+            json=CompletionResponse(
+                id="1",
+                choices=[Choice(message=ChoiceMessage(content="hello"))],
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ).model_dump(),
+        )
+
+        provider = CerebrasProvider()
+
+        out = await provider.complete(
+            [MessageDeprecated(role=MessageDeprecated.Role.USER, content="hi")],
+            options=ProviderOptions(model=Model.LLAMA_3_1_8B, max_tokens=5, temperature=0),
+            output_factory=lambda x, _: StructuredOutput(json.loads(x)),
+        )
+
+        assert out.output == "hello"
+        request = httpx_mock.get_requests()[0]
+        body = json.loads(request.read().decode())
+        assert body["stream"] is False
+
+    async def test_stream(self, httpx_mock: HTTPXMock):
+        stream_events = [
+            b'data: {"id":"1","choices":[{"delta":{"content":"he"}}]}\n\n',
+            b'data: {"id":"1","choices":[{"delta":{"content":"llo"},"finish_reason":"stop"}]}\n\n',
+            b"data: [DONE]",
+        ]
+        httpx_mock.add_response(
+            url="https://api.cerebras.ai/v1/chat/completions",
+            stream=IteratorStream(stream_events),
+        )
+
+        provider = CerebrasProvider()
+        streamer = provider.stream(
+            [MessageDeprecated(role=MessageDeprecated.Role.USER, content="hi")],
+            options=ProviderOptions(model=Model.LLAMA_3_1_8B, max_tokens=5, temperature=0),
+            output_factory=lambda x, _: StructuredOutput(x),
+            partial_output_factory=lambda x: StructuredOutput(x),
+        )
+        chunks = [c async for c in streamer]
+        assert chunks[-1].output == "hello"
+
+
+class TestListModels:
+    async def test_list_models(self, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            url="https://api.cerebras.ai/v1/models",
+            json={"data": [{"id": "llama3-8b"}, {"id": "llama3-70b"}]},
+        )
+
+        provider = CerebrasProvider()
+        models = await provider.list_models()
+        assert models == ["llama3-8b", "llama3-70b"]

--- a/api/core/providers/factory/local_provider_factory.py
+++ b/api/core/providers/factory/local_provider_factory.py
@@ -14,6 +14,7 @@ from core.providers.anthropic.anthropic_provider import AnthropicProvider
 from core.providers.base.abstract_provider import AbstractProvider, ProviderConfigVar
 from core.providers.factory.abstract_provider_factory import AbstractProviderFactory
 from core.providers.fireworks.fireworks_provider import FireworksAIProvider
+from core.providers.cerebras.cerebras_provider import CerebrasProvider
 from core.providers.google.gemini.gemini_api_provider import GoogleGeminiAPIProvider
 from core.providers.google.google_provider import GoogleProvider
 from core.providers.google_imagen.google_imagen_vertex_provider import (
@@ -36,6 +37,7 @@ _provider_cls: list[type[AbstractProvider[Any, Any]]] = [
     AnthropicProvider,
     GoogleGeminiAPIProvider,
     FireworksAIProvider,
+    CerebrasProvider,
     XAIProvider,
     OpenAIImageProvider,
     GoogleImagenVertexProvider,


### PR DESCRIPTION
## Summary
- implement Cerebras provider and domain models
- register new provider and enums
- document new env vars and update README
- add provider pricing placeholder
- include provider factory wiring and unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.warnings')*

------
https://chatgpt.com/codex/tasks/task_e_68408c3052788321bb44ba52c28758bb