### PR TITLE
Fix object check in ProxyTools

### DIFF
--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/proxy-playground/parameters-section/ProxyTools.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/proxy-playground/parameters-section/ProxyTools.tsx
@@ -22,7 +22,7 @@ export function ProxyTools(props: ProxyToolsProps) {
 
     const result: Tool_Output[] = [];
     toolCalls.forEach((tool) => {
-      if ('name' in (tool as Tool_Output)) {
+      if (typeof tool === 'object' && tool && 'name' in tool) {
         result.push(tool as Tool_Output);
       }
     });


### PR DESCRIPTION
## Summary
- fix runtime error when tool is not an object in ProxyTools

## Testing
- `make lint` *(fails: Import "taskiq" could not be resolved)*
- `yarn --cwd client test`

------
https://chatgpt.com/codex/tasks/task_e_6844a128a9a483219c46c73826c3f1a9