### PR TITLE
schema edition and playground agent updates for schema edition

### DIFF
--- a/api/api/routers/tasks.py
+++ b/api/api/routers/tasks.py
@@ -125,6 +125,7 @@ async def generate_via_chat(
                 chat_messages=chat_messages,
                 user_email=user_properties.user_email,
                 existing_task=existing_task,
+                is_proxy_agent=request.is_proxy_agent,
             ):
                 payload = BuildAgentIteration(
                     user_message=request.user_message,

--- a/api/api/schemas/build_task_request.py
+++ b/api/api/schemas/build_task_request.py
@@ -80,3 +80,4 @@ class BuildAgentRequest(BaseModel):
 
     user_message: str
     stream: bool = Field(default=False, description="Whether to stream the task building process")
+    is_proxy_agent: bool = Field(default=False, description="Whether the agent is a proxy agent")


### PR DESCRIPTION
Closes [WOR-4777: Allow proxy user to edit output schema](https://linear.app/workflowai/issue/WOR-4777/allow-proxy-user-to-edit-output-schema)

@jacekzimonski you now need to pass `is_proxy_agent=True` when iterating on a proxy agent schema, then the agent will only generate an output schema.