### PR TITLE
Fix UTF-8 streaming in JSON parser

### DIFF
--- a/api/core/utils/streams_test.py
+++ b/api/core/utils/streams_test.py
@@ -217,6 +217,12 @@ def test_new_line_and_quote() -> None:
     assert agg[-1] == ("answer", '"Red"\n"Blue"')
 
 
+def test_unicode_escape_across_chunks() -> None:
+    chunks = ['{"a": "\\u202', '2"}']
+    agg = _agg_stream(chunks)
+    assert agg == [("a", "•")]
+
+
 def test_invalid_json_with_comma() -> None:
     chunks = ["{\n", "}", ","]
     # The last comma is not part of the json so we check the json without it


### PR DESCRIPTION
## Summary
- improve JSONStreamParser to handle `\uXXXX` unicode escapes across chunks
- add test for streaming unicode escape sequences

## Testing
- `poetry run ruff check api/core/utils/streams.py api/core/utils/streams_test.py`
- `poetry run pyright api/core/utils/streams.py api/core/utils/streams_test.py`
- `poetry run pytest api/core/utils/streams_test.py::test_unicode_escape_across_chunks -q`


------
https://chatgpt.com/codex/tasks/task_e_6848286bc29883218201a6626bd038f1