### PR TITLE
Add reasoning effort and expose reasoning output

### DIFF
--- a/api/api/routers/openai_proxy/_openai_proxy_models.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_models.py
@@ -206,6 +206,8 @@ class OpenAIProxyMessage(BaseModel):
     name: str | None = None
     role: str
 
+    reasoning_content: str | None = None
+
     tool_calls: list[OpenAIProxyToolCall] | None = None
     function_call: OpenAIProxyFunctionCall | None = None  # Deprecated
     tool_call_id: str | None = None
@@ -221,6 +223,7 @@ class OpenAIProxyMessage(BaseModel):
             function_call=OpenAIProxyFunctionCall.from_domain(run.tool_call_requests[0])
             if run.tool_call_requests and deprecated_function
             else None,
+            reasoning_content=run.thoughts,
         )
 
     @property
@@ -847,6 +850,7 @@ class OpenAIProxyChatCompletionChunkDelta(BaseModel):
     function_call: OpenAIProxyFunctionCall | None  # Deprecated
     tool_calls: list[OpenAIProxyToolCall] | None
     role: Literal["user", "assistant", "system", "tool"] | None
+    reasoning_content: str | None = None
 
     @classmethod
     def from_domain(cls, output: RunOutput, deprecated_function: bool):
@@ -861,6 +865,7 @@ class OpenAIProxyChatCompletionChunkDelta(BaseModel):
             tool_calls=[OpenAIProxyToolCall.from_domain(t) for t in output.tool_call_requests]
             if output.tool_call_requests and not deprecated_function
             else None,
+            reasoning_content=output.thoughts,
         )
 
 

--- a/api/core/domain/agent_run.py
+++ b/api/core/domain/agent_run.py
@@ -128,6 +128,8 @@ class AgentRun(AgentRunBase):
 
     conversation_id: str | None = None
 
+    thoughts: str | None = None
+
     @property
     def used_environment(self) -> str | None:
         if not self.metadata:

--- a/api/core/domain/run_output.py
+++ b/api/core/domain/run_output.py
@@ -12,6 +12,7 @@ class RunOutput(NamedTuple):
     tool_call_requests: Sequence[ToolCallRequestWithID] | None = None
     reasoning_steps: list[InternalReasoningStep] | None = None
     delta: str | None = None
+    thoughts: str | None = None
 
     @classmethod
     def from_run(cls, run: AgentRun, delta: str | None = None):
@@ -21,4 +22,5 @@ class RunOutput(NamedTuple):
             tool_call_requests=run.tool_call_requests,
             reasoning_steps=run.reasoning_steps,
             delta=delta,
+            thoughts=run.thoughts,
         )

--- a/api/core/domain/structured_output.py
+++ b/api/core/domain/structured_output.py
@@ -22,6 +22,8 @@ class StructuredOutput(NamedTuple):
 
     delta: str | None = None
 
+    thoughts: str | None = None
+
     @property
     def number_of_images(self) -> int:
         if not self.files:

--- a/api/core/domain/task_group_properties.py
+++ b/api/core/domain/task_group_properties.py
@@ -109,6 +109,11 @@ class TaskGroupProperties(BaseModel):
         description="Whether to allow the model to output mutliple tool calls",
     )
 
+    reasoning_effort: str | int | None = Field(
+        default=None,
+        description="The reasoning effort or thinking budget used for the run",
+    )
+
     messages: list[Message] | None = None
 
     def model_hash(self) -> str:

--- a/api/core/domain/task_run_builder.py
+++ b/api/core/domain/task_run_builder.py
@@ -144,6 +144,7 @@ class TaskRunBuilder(BaseModel):
             tool_calls=list(output.tool_calls) if output and output.tool_calls else None,
             tool_call_requests=list(output.tool_call_requests) if output and output.tool_call_requests else None,
             reasoning_steps=output.reasoning_steps if output else None,
+            thoughts=output.thoughts if output else None,
             metadata=metadata or None,
             status="failure" if error else "success",
             error=error,

--- a/api/core/providers/base/provider_options.py
+++ b/api/core/providers/base/provider_options.py
@@ -23,3 +23,5 @@ class ProviderOptions(BaseModel):
     presence_penalty: float | None = None
     frequency_penalty: float | None = None
     parallel_tool_calls: bool | None = None
+
+    reasoning_effort: str | int | None = None

--- a/api/core/providers/base/streaming_context.py
+++ b/api/core/providers/base/streaming_context.py
@@ -17,6 +17,7 @@ class ToolCallRequestBuffer(BaseModel):
 class ParsedResponse(NamedTuple):
     content: str
     reasoning_steps: str | None = None
+    thoughts: str | None = None
     # TODO: switch to tool call request
     tool_calls: list[ToolCallRequestWithID] | None = None
 
@@ -27,6 +28,7 @@ class StreamingContext:
         self.streamer = JSONStreamParser() if json else RawStreamParser()
         self.agg_output: dict[str, Any] = {}
         self.reasoning_steps: list[InternalReasoningStep] | None = None
+        self.thoughts: str | None = None
         self.raw_completion = raw_completion
 
         self.tool_call_request_buffer: dict[int, ToolCallRequestBuffer] = {}

--- a/api/core/providers/fireworks/fireworks_provider.py
+++ b/api/core/providers/fireworks/fireworks_provider.py
@@ -364,10 +364,10 @@ class FireworksAIProvider(HTTPXProvider[FireworksConfig, CompletionResponse]):
     def _check_for_closing_thinking_tag(self, content: str, tool_calls: list[ToolCallRequestWithID] | None):
         index = content.find("</think>")
         if index == -1:
-            return ParsedResponse("", content, tool_calls=tool_calls)
+            return ParsedResponse("", thoughts=content, tool_calls=tool_calls)
 
         self._thinking_tag_context.set(False)
-        return ParsedResponse(content[index + len("</think>") :], content[:index], tool_calls=tool_calls)
+        return ParsedResponse(content[index + len("</think>") :], thoughts=content[:index], tool_calls=tool_calls)
 
     def _check_for_thinking_tag(self, content: str, tool_calls: list[ToolCallRequestWithID] | None):
         # We only consider full tags in streams for now

--- a/api/core/providers/openai/openai_provider_base.py
+++ b/api/core/providers/openai/openai_provider_base.py
@@ -126,7 +126,7 @@ class OpenAIProviderBase(HTTPXProvider[_OpenAIConfigVar, CompletionResponse], Ge
             stream_options=StreamOptions(include_usage=True) if stream else None,
             # store=True,
             response_format=self._response_format(options, is_preview_model),
-            reasoning_effort=_REASONING_EFFORT_FOR_MODEL.get(options.model, None),
+            reasoning_effort=options.reasoning_effort or _REASONING_EFFORT_FOR_MODEL.get(options.model, None),
             tool_choice=CompletionRequest.tool_choice_from_domain(options.tool_choice),
             top_p=options.top_p,
             presence_penalty=options.presence_penalty,

--- a/api/core/providers/xai/xai_provider.py
+++ b/api/core/providers/xai/xai_provider.py
@@ -81,7 +81,8 @@ class XAIProvider(HTTPXProvider[XAIConfig, CompletionResponse]):
 
         model_data = get_model_data(options.model)
 
-        model_value, reasoning_effort = THINKING_MODEL_MAP.get(options.model, (options.model.value, None))
+        model_value, default_effort = THINKING_MODEL_MAP.get(options.model, (options.model.value, None))
+        reasoning_effort = options.reasoning_effort or default_effort
 
         completion_request = CompletionRequest(
             messages=message,

--- a/api/core/runners/workflowai/workflowai_options.py
+++ b/api/core/runners/workflowai/workflowai_options.py
@@ -60,3 +60,5 @@ class WorkflowAIRunnerOptions(BaseModel):
     frequency_penalty: float | None = None
 
     parallel_tool_calls: bool | None = None
+
+    reasoning_effort: str | int | None = None

--- a/api/core/runners/workflowai/workflowai_runner.py
+++ b/api/core/runners/workflowai/workflowai_runner.py
@@ -847,6 +847,7 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
             tool_calls=internal_tools or None,
             tool_call_requests=external_tools or None,
             reasoning_steps=output.reasoning_steps,
+            thoughts=output.thoughts,
         )
 
     async def _build_task_output_from_messages(
@@ -1062,6 +1063,7 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
             enabled_tools=list(self._all_tools()),
             tool_choice=self._options.tool_choice,
             timeout=self._timeout,
+            reasoning_effort=self._options.reasoning_effort,
         )
 
         model_data_copy = model_data.model_copy()
@@ -1117,7 +1119,7 @@ class WorkflowAIRunner(AbstractRunner[WorkflowAIRunnerOptions]):
                     continue
 
                 # TODO[tools]: add tool calls and tool call requests
-                yield RunOutput(task_output=output.output, reasoning_steps=output.reasoning_steps, delta=output.delta)
+                yield RunOutput(task_output=output.output, reasoning_steps=output.reasoning_steps, delta=output.delta, thoughts=output.thoughts)
 
             if not output:
                 # We never had any output, we can stop the stream

--- a/api/core/utils/reasoning.py
+++ b/api/core/utils/reasoning.py
@@ -1,0 +1,23 @@
+REASONING_EFFORT_TO_BUDGET = {
+    "low": 1024,
+    "medium": 8192,
+    "high": 16384,
+}
+
+
+def reasoning_effort_to_budget(reasoning_effort: str | int, max_output_tokens: int) -> int:
+    if isinstance(reasoning_effort, int):
+        return reasoning_effort
+    if reasoning_effort == "highest":
+        return max_output_tokens - 1
+    return REASONING_EFFORT_TO_BUDGET.get(reasoning_effort, 0)
+
+
+def budget_to_reasoning_effort(budget: int, max_output_tokens: int) -> str:
+    for effort, val in REASONING_EFFORT_TO_BUDGET.items():
+        if budget == val:
+            return effort
+    if budget >= max_output_tokens - 1:
+        return "highest"
+    # Default to low if unknown
+    return "low"

--- a/docs/features/thinking-mode.md
+++ b/docs/features/thinking-mode.md
@@ -1,0 +1,90 @@
+---
+title: Thinking Mode
+description: Enable thinking mode on capable models and retrieve the thoughts.
+---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## What is Thinking Mode?
+
+Thinking mode is an advanced reasoning capability available in certain AI models that allows them to engage in explicit step-by-step reasoning before providing their final answer. When thinking mode is enabled, the model generates internal "thoughts" that show its reasoning process, problem-solving steps, and decision-making logic.
+
+Thinking mode can unlock better inference capabilities in complex use cases; however, it can add extra cost and latency, since the **thoughts** are generated prior to the response and count towards the used tokens. It is important to consider the trade-off when enabling thinking mode.
+
+## Configuration
+
+All providers have a different way of configuring thinking mode or returning thoughts:
+- [OpenAI](https://platform.openai.com/docs/guides/reasoning) and [xAI](https://docs.x.ai/docs/guides/reasoning) expose a **reasoning effort** parameter (`low`, `medium`, `high`).
+- [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) and [Google](https://ai.google.dev/gemini-api/docs/thinking) allow providing a thinking budget, limiting the number of tokens used for thinking.
+- Fireworks does not support configuring thinking mode
+
+To rationalize differences between providers, WorkflowAI relies on the completion API [reasoning effort parameter](https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort) and allows passing either:
+- an OpenAI style reasoning effort (`low`, `medium`, `high`), which is converted to a thinking budget when needed.
+- `highest` which will be converted to the max number of tokens for thinking depending on the model
+- an `integer` for a thinking budget, which is converted to a reasoning effort when needed
+
+The mapping from reasoning effort to thinking budget is described in the below table. The reverse mapping follows a similar pattern.
+
+| Reasoning Effort | Thinking Budget |
+|-----------------|-----------------|
+| `low`           | 1024            |
+| `medium`        | 8192            |
+| `high`          | 16384           |
+| `highest`       | max output tokens of the model - 1           |
+
+## Usage
+
+As explained above, the reasoning effort can be passed as a parameter to the completion API. Thoughts can then be retrieved from the choice object via a WorkflowAI specific field `reasoning_content`.
+
+<Callout type="warning">
+As the `reasoning_content` field is not part of the OpenAI API, it will likely throw a typing issue when accessed.
+</Callout>
+
+<Tabs items={["Python", "TypeScript", "JSON"]}>
+  <Tab>
+  ```python
+  res = openai.chat.completions.create(
+    model="o3-mini",
+    messages=[{"role": "user", "content": "What is the meaning of life?"}],
+    reasoning_effort="high", # or e.g. 16384
+  )
+  # Access the thoughts
+  print(res.choices[0].message.reasoning_content) # type: ignore
+  ```
+  </Tab>
+  <Tab>
+  ```typescript
+  const res = await openai.chat.completions.create({
+    model: "o3-mini",
+    messages: [{ role: "user", content: "What is the meaning of life?" }],
+    reasoning_effort: "high", // or e.g. 16384
+  });
+  // Access the thoughts
+  // @ts-expect-error - reasoning_content is not part of the OpenAI API
+  console.log(res.choices[0].message.reasoning_content); 
+  ```
+  </Tab>
+  <Tab>
+  ```json
+  {
+    "model": "o3-mini",
+    "messages": [
+      {
+        "role": "user", 
+        "content": "What is the meaning of life?"
+      }
+    ],
+    "reasoning_effort": "high"
+  }
+  ```
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+When streaming, the thoughts deltas are also returned beside the content.
+</Callout>
+
+<Callout type="info">
+For historic reasons, the reasoning effort can sometimes be included in the model id, e.g. `o3-2025-04-16-high`. Passing the reasoning effort separately from the model id is now preferred.
+</Callout>


### PR DESCRIPTION
## Summary
- expose reasoning_content in OpenAI proxy models
- avoid duplicating provider thoughts in REST responses
- document how to use thinking mode

## Testing
- `poetry run ruff check api/api/routers/openai_proxy/_openai_proxy_models.py api/api/routers/run.py`
- `poetry run pyright api/api/routers/openai_proxy/_openai_proxy_models.py api/api/routers/run.py`
- `pyright run ruff check api/api/routers/openai_proxy/_openai_proxy_models.py api/api/routers/run.py` *(fails: File or directory "file:///workspace/WorkflowAI/run" does not exist)*
- `pyright run pyright api/api/routers/openai_proxy/_openai_proxy_models.py api/api/routers/run.py` *(fails: File or directory "file:///workspace/WorkflowAI/run" does not exist)*
- `poetry run pytest api/tests/component/openai_proxy/openai_proxy_test.py::test_raw_string_output -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_684894d3a904832e9f626bbd08b42bcb