### PR TITLE
Sort tasks by recent activity

### DIFF
--- a/client/src/app/[tenant]/agents/tasks/utils.tsx
+++ b/client/src/app/[tenant]/agents/tasks/utils.tsx
@@ -1,4 +1,4 @@
-import { filterActiveTasksIDs } from '@/lib/taskUtils';
+import { getLatestActivityDate } from '@/lib/taskUtils';
 import { SerializableTask } from '@/types/workflowAI';
 
 export function filterTasks(tasks: SerializableTask[], searchQuery: string) {
@@ -26,33 +26,19 @@ export function filterTasks(tasks: SerializableTask[], searchQuery: string) {
 }
 
 export function sortTasks(tasks: SerializableTask[]) {
-  const activeTasksIds = filterActiveTasksIDs(tasks);
-
   return tasks.sort((a, b) => {
-    // First priority: run_count
-    if (!!a.run_count && !!b.run_count) {
-      return b.run_count - a.run_count;
-    }
+    const aDate = getLatestActivityDate(a);
+    const bDate = getLatestActivityDate(b);
 
-    if (!a.run_count && !!b.run_count) {
-      return 1;
-    }
-    if (!!a.run_count && !b.run_count) {
+    if (aDate && bDate) {
+      if (aDate > bDate) return -1;
+      if (aDate < bDate) return 1;
+    } else if (aDate && !bDate) {
       return -1;
-    }
-
-    // Second priority: active status
-    const aIsActive = activeTasksIds.includes(a.id);
-    const bIsActive = activeTasksIds.includes(b.id);
-
-    if (aIsActive && !bIsActive) {
-      return -1;
-    }
-    if (!aIsActive && bIsActive) {
+    } else if (!aDate && bDate) {
       return 1;
     }
 
-    // Last priority: alphabetical by name/id
     const aName = a.name.length === 0 ? a.id : a.name;
     const bName = b.name.length === 0 ? b.id : b.name;
     return aName.localeCompare(bName);

--- a/client/src/lib/taskUtils.tsx
+++ b/client/src/lib/taskUtils.tsx
@@ -70,3 +70,19 @@ export function isActiveTask(task?: SerializableTask) {
 export function filterActiveTasksIDs(tasks: SerializableTask[]): string[] {
   return tasks.filter((task) => isActiveTask(task)).map((task) => task.id);
 }
+
+export function getLatestActivityDate(task?: SerializableTask): Date | undefined {
+  if (!task) return undefined;
+
+  let latest: Date | undefined;
+  task.versions.forEach(({ last_active_at }) => {
+    if (last_active_at) {
+      const current = new Date(last_active_at);
+      if (!latest || current > latest) {
+        latest = current;
+      }
+    }
+  });
+
+  return latest;
+}

--- a/client/src/store/task.ts
+++ b/client/src/store/task.ts
@@ -1,6 +1,7 @@
 import { enableMapSet, produce } from 'immer';
-import { orderBy, sortBy } from 'lodash';
+import { orderBy } from 'lodash';
 import { create } from 'zustand';
+import { sortTasks } from '@/app/[tenant]/agents/tasks/utils';
 import { client } from '@/lib/api';
 import { Method, SSEClient } from '@/lib/api/client';
 import { TaskID, TaskSchemaID, TenantID } from '@/types/aliases';
@@ -131,11 +132,11 @@ export const useTasks = create<TasksState>((set, get) => ({
       // in the JWT
       const { items } = await client.get<Page_SerializableTask_>(rootTaskPath(tenant));
 
-      const sortedTasksByName = sortBy(items, 'name');
-      const sortedTasksWithSortedVersions = sortedTasksByName.map((task) => ({
+      const tasksWithSortedVersions = items.map((task) => ({
         ...task,
         versions: orderBy(task.versions, 'schema_id', 'desc'),
       }));
+      const sortedTasksWithSortedVersions = sortTasks(tasksWithSortedVersions);
       set(
         produce((state: TasksState) => {
           state.tasksByTenant.set(tenant, sortedTasksWithSortedVersions);


### PR DESCRIPTION
## Summary
- prioritize tasks based on last active date
- expose helper to get the latest activity timestamp
- use new sort strategy when fetching tasks

## Testing
- `yarn prettier-check`
- `yarn workspace workflowai lint`
- `yarn workspace workflowai build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6848a0cab8fc8321837ff46ac361e0f2