### PR TITLE
Add pricing info to models API

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -163,9 +163,15 @@ class StandardModelResponse(BaseModel):
         display_name: str
         icon_url: str
         supports: dict[str, Any]
+        class Pricing(BaseModel):
+            input_token_usd: float
+            output_token_usd: float
+
+        pricing: Pricing
 
         @classmethod
         def from_model_data(cls, id: str, model: FinalModelData):
+            provider_data = model.providers[0][1]
             return cls(
                 id=id,
                 created=int(datetime.datetime.combine(model.release_date, datetime.time(0, 0)).timestamp()),
@@ -179,6 +185,10 @@ class StandardModelResponse(BaseModel):
                         include=set(ModelDataSupports.model_fields.keys()),
                     ).items()
                 },
+                pricing=cls.Pricing(
+                    input_token_usd=provider_data.text_price.prompt_cost_per_token,
+                    output_token_usd=provider_data.text_price.completion_cost_per_token,
+                ),
             )
 
     data: list[ModelItem]

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -103,7 +103,6 @@ async def lifespan(app: FastAPI):
     await HTTPXProviderBase.close()
 
 
-
 _ONLY_RUN_ROUTES = os.getenv("ONLY_RUN_ROUTES") == "true"
 
 app = FastAPI(
@@ -163,11 +162,14 @@ class StandardModelResponse(BaseModel):
         display_name: str
         icon_url: str
         supports: dict[str, Any]
+
         class Pricing(BaseModel):
             input_token_usd: float
             output_token_usd: float
 
         pricing: Pricing
+
+        release_date: datetime.date
 
         @classmethod
         def from_model_data(cls, id: str, model: FinalModelData):
@@ -189,6 +191,7 @@ class StandardModelResponse(BaseModel):
                     input_token_usd=provider_data.text_price.prompt_cost_per_token,
                     output_token_usd=provider_data.text_price.completion_cost_per_token,
                 ),
+                release_date=model.release_date,
             )
 
     data: list[ModelItem]

--- a/api/api/main_test.py
+++ b/api/api/main_test.py
@@ -180,6 +180,10 @@ class TestModelsEndpoint:
         assert first_model["object"] == "model"
         assert "supports" in first_model
         assert "parallel_tool_calls" in first_model["supports"]
+        assert "pricing" in first_model
+        pricing = cast(dict[str, Any], first_model["pricing"])
+        assert "input_token_usd" in pricing
+        assert "output_token_usd" in pricing
 
     async def test_models_endpoint_order_check(self, test_api_client: AsyncClient, mock_tenant_dep: Mock):
         # Making sure we raise if the tenant dep is called

--- a/api/api/main_test.py
+++ b/api/api/main_test.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from typing import Any, Iterator, cast
 from unittest.mock import Mock
@@ -184,6 +185,10 @@ class TestModelsEndpoint:
         pricing = cast(dict[str, Any], first_model["pricing"])
         assert "input_token_usd" in pricing
         assert "output_token_usd" in pricing
+
+        assert "release_date" in first_model
+        release_date = cast(str, first_model["release_date"])
+        assert re.match(r"\d{4}-\d{2}-\d{2}", release_date)
 
     async def test_models_endpoint_order_check(self, test_api_client: AsyncClient, mock_tenant_dep: Mock):
         # Making sure we raise if the tenant dep is called


### PR DESCRIPTION
## Summary
- return per-token pricing in `/v1/models`
- check new pricing info in tests

## Testing
- `pyright run ruff check .` *(fails: File or directory "file:///workspace/WorkflowAI/run" does not exist)*
- `poetry run ruff check api/api/main.py api/api/main_test.py`
- `pyright run pyright .` *(fails: File or directory "file:///workspace/WorkflowAI/run" does not exist)*
- `poetry run pyright api/api/main.py api/api/main_test.py`
- `poetry run pytest api/tests/component/models/models_test.py::test_list_models_get -q` *(fails: ServerSelectionTimeoutError: localhost:27017)*
- `poetry run pytest api/api/main_test.py::TestModelsEndpoint::test_openai_compatibility -q`


------
https://chatgpt.com/codex/tasks/task_e_68497d3d176c832e8ae1fbeb1eff4a16