### PR TITLE
Fix analytics not setting task properties for proxy runs

### DIFF
--- a/api/api/routers/openai_proxy/_openai_proxy_handler.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler.py
@@ -93,11 +93,15 @@ class OpenAIProxyHandler:
 
     def _update_event_router(self, tenant_data: PublicOrganizationData, variant: SerializableTaskVariant):
         try:
-            self._event_router.task_properties = TaskProperties.build(  # pyright: ignore [reportAttributeAccessIssue]
+            properties = TaskProperties.build(  # pyright: ignore [reportAttributeAccessIssue]
                 variant.task_id,
                 variant.task_schema_id,
                 tenant_data,
             )
+            self._event_router.task_properties = properties  # pyright: ignore [reportAttributeAccessIssue]
+            # Keep analytics service in sync so events contain task info
+            if hasattr(self._run_service, "analytics_service"):
+                self._run_service.analytics_service.task_properties = properties  # pyright: ignore [reportAttributeAccessIssue]
         except Exception:
             _logger.exception("Could not set task properties for event router")
 


### PR DESCRIPTION
## Summary
- ensure OpenAI proxy updates analytics task properties on the run service

## Testing
- `poetry run ruff check api/api/routers/openai_proxy/_openai_proxy_handler.py`
- `poetry run pyright api/api/routers/openai_proxy/_openai_proxy_handler.py`
- `poetry run pytest api/tests/component/openai_proxy/openai_proxy_test.py::test_raw_string_output -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_684a1037df4c8331bc9c8303122a71cf