### PR TITLE
avoid using messages naming in legacy agent input

### DIFF
--- a/api/api/services/internal_tasks/custom_tool_creation_service.py
+++ b/api/api/services/internal_tasks/custom_tool_creation_service.py
@@ -38,7 +38,7 @@ class CustomToolService:
     ) -> AsyncIterator[CustomToolCreationChatMessage]:
         async for output in stream_custom_tool_creation_agent(
             CustomToolCreationAgentInput(
-                messages=messages,
+                chat_messages=messages,
             ),
         ):
             if answer := output.answer:

--- a/api/api/services/internal_tasks/integration_service.py
+++ b/api/api/services/internal_tasks/integration_service.py
@@ -166,7 +166,7 @@ class IntegrationService:
         return IntegrationAgentInput(
             current_datetime=datetime.datetime.now(),
             integration=integration,
-            messages=self._get_integration_agent_chat_messages(messages),
+            chat_messages=self._get_integration_agent_chat_messages(messages),
             documentation=list(
                 set(relevant_documentation_sections + integration_documentation_sections),  # Deduplicate
             ),

--- a/api/api/services/internal_tasks/integration_service_test.py
+++ b/api/api/services/internal_tasks/integration_service_test.py
@@ -142,11 +142,11 @@ class TestBuildIntegrationChatAgentInput:
         result = await integration_service._build_integration_chat_agent_input(messages, Mock(spec=Integration))  # pyright: ignore[reportPrivateUsage]
 
         assert isinstance(result, IntegrationAgentInput)
-        assert len(result.messages) == 2
-        assert result.messages[0].role == "USER"
-        assert result.messages[0].content == "Hello"
-        assert result.messages[1].role == "ASSISTANT"
-        assert result.messages[1].content == "Hi there"
+        assert len(result.chat_messages) == 2
+        assert result.chat_messages[0].role == "USER"
+        assert result.chat_messages[0].content == "Hello"
+        assert result.chat_messages[1].role == "ASSISTANT"
+        assert result.chat_messages[1].content == "Hi there"
 
 
 class TestGetInitialCodeSnippetMessages:

--- a/api/api/services/internal_tasks/meta_agent_service.py
+++ b/api/api/services/internal_tasks/meta_agent_service.py
@@ -721,7 +721,7 @@ class MetaAgentService:
 
         return MetaAgentInput(
             current_datetime=datetime.datetime.now(tz=datetime.timezone.utc),
-            messages=[message.to_domain() for message in messages],
+            chat_messages=[message.to_domain() for message in messages],
             latest_messages_url_content=await self._extract_url_content_from_messages(messages),
             company_context=MetaAgentInput.CompanyContext(
                 company_name=context.company_description.company_name if context.company_description else None,

--- a/api/api/services/internal_tasks/meta_agent_service_test.py
+++ b/api/api/services/internal_tasks/meta_agent_service_test.py
@@ -62,7 +62,7 @@ class TestMetaAgentService:
                 ["Agent 1", "Agent 2"],
                 MetaAgentInput(
                     current_datetime=datetime.datetime(2025, 1, 1),
-                    messages=[MetaAgentChatMessage(role="USER", content="Hello").to_domain()],
+                    chat_messages=[MetaAgentChatMessage(role="USER", content="Hello").to_domain()],
                     company_context=MetaAgentInput.CompanyContext(
                         company_name="Example Corp",
                         company_description="A tech company",
@@ -100,7 +100,7 @@ class TestMetaAgentService:
                 [],  # No agents
                 MetaAgentInput(
                     current_datetime=datetime.datetime(2025, 1, 1),
-                    messages=[MetaAgentChatMessage(role="USER", content="Help").to_domain()],
+                    chat_messages=[MetaAgentChatMessage(role="USER", content="Help").to_domain()],
                     company_context=MetaAgentInput.CompanyContext(
                         company_name=None,
                         company_description=None,
@@ -225,7 +225,7 @@ class TestMetaAgentService:
             mock_get_relevant_doc_sections.assert_called_once()
 
             # Verify the result
-            assert result.messages == expected_input.messages
+            assert result.chat_messages == expected_input.chat_messages
             assert result.company_context.company_name == expected_input.company_context.company_name
             assert result.company_context.company_description == expected_input.company_context.company_description
             assert result.company_context.company_locations == expected_input.company_context.company_locations
@@ -369,7 +369,7 @@ class TestMetaAgentService:
         # Create a mock for _build_meta_agent_input
         mock_input = MetaAgentInput(
             current_datetime=datetime.datetime(2025, 1, 1),
-            messages=[message.to_domain() for message in messages],
+            chat_messages=[message.to_domain() for message in messages],
             company_context=MetaAgentInput.CompanyContext(),
             workflowai_documentation_sections=[
                 DocumentationSection(title="Some title", content="Some content"),

--- a/api/core/agents/custom_tool/custom_tool_creation_agent.py
+++ b/api/core/agents/custom_tool/custom_tool_creation_agent.py
@@ -7,7 +7,7 @@ from core.domain.fields.custom_tool_creation_chat_message import CustomToolCreat
 
 
 class CustomToolCreationAgentInput(BaseModel):
-    messages: list[CustomToolCreationChatMessage] | None = Field(
+    chat_messages: list[CustomToolCreationChatMessage] | None = Field(
         default=None,
         description="The list of previous messages in the conversation, the last message is the most recent one",
     )

--- a/api/core/agents/integration_agent.py
+++ b/api/core/agents/integration_agent.py
@@ -24,7 +24,7 @@ class IntegrationAgentInput(BaseModel):
     documentation: list[DocumentationSection] = Field(
         description="The documentation sections that are relevant to the conversation.",
     )
-    messages: list[IntegrationAgentChatMessage] = Field(
+    chat_messages: list[IntegrationAgentChatMessage] = Field(
         description="The list of messages in the conversation, the last message being the most recent one.",
     )
     integration: Integration = Field(

--- a/api/core/agents/meta_agent.py
+++ b/api/core/agents/meta_agent.py
@@ -338,7 +338,7 @@ class MetaAgentInput(BaseModel):
         description="The current datetime",
     )
 
-    messages: list[MetaAgentChatMessage] = Field(
+    chat_messages: list[MetaAgentChatMessage] = Field(
         description="The list of messages in the conversation, the last message being the most recent one",
     )
 
@@ -649,5 +649,4 @@ META_AGENT_INSTRUCTIONS = """You are WorkflowAI's meta-agent. You are responsibl
         max_tokens=1000,
     ),
 )
-async def meta_agent(_: MetaAgentInput) -> MetaAgentOutput:
-    ...
+async def meta_agent(_: MetaAgentInput) -> MetaAgentOutput: ...

--- a/api/core/agents/suggest_llm_features_for_company_agent.py
+++ b/api/core/agents/suggest_llm_features_for_company_agent.py
@@ -102,7 +102,7 @@ class SuggestLlmAgentForCompanyInput(BaseModel):
         description="The context of the company",
     )
 
-    messages: list[AgentSuggestionChatMessage] | None = Field(
+    chat_messages: list[AgentSuggestionChatMessage] | None = Field(
         default=None,
         description="The list of previous messages in the conversation, the last message is the most recent one",
     )


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-4945/legacy-agent-crashes-when-input-contains-messages-field

Related to [WOR-4945: Legacy agent crashes when input contains 'messages' field](https://linear.app/workflowai/issue/WOR-4945/legacy-agent-crashes-when-input-contains-messages-field)

Which requires @guillaq's attention