### PR TITLE
Fix copy model tooltip

### DIFF
--- a/client/src/components/AIModelsCombobox/labels/ModelLabel.tsx
+++ b/client/src/components/AIModelsCombobox/labels/ModelLabel.tsx
@@ -60,11 +60,10 @@ export function ModelLabel(props: ModelLabelProps) {
   const onCopyModelId = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
-      const text = taskId ? `${taskId}/${model.id}` : model.id;
-      copy(text);
+      copy(model.id);
       displaySuccessToaster('Copied to clipboard');
     },
-    [model.id, copy, taskId]
+    [model.id, copy]
   );
 
   return (
@@ -98,7 +97,7 @@ export function ModelLabel(props: ModelLabelProps) {
               content={
                 <div>
                   <span>Copy model id: </span>
-                  <span className='text-gray-300'>{`${taskId}/${model.id}`}</span>
+                  <span className='text-gray-300'>{model.id}</span>
                 </div>
               }
               side='top'


### PR DESCRIPTION
## Summary
- adjust model ID tooltip in ModelLabel to remove agent prefix

## Testing
- `yarn prettier-check client/src/components/AIModelsCombobox/labels/ModelLabel.tsx`
- `yarn workspace workflowai lint`
- `NODE_OPTIONS=--max-old-space-size=6144 yarn workspace workflowai build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_684b4337ce4483319e7ee90ca48a71e2