### PR TITLE
Fix documentation imports and revert font change

### DIFF
--- a/docsv2/app/(docs)/[[...slug]]/page.tsx
+++ b/docsv2/app/(docs)/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
+import type { MDXComponents } from 'mdx/types';
 import { getMDXComponents } from '@/mdx-components';
 import { getLLMText } from '@/lib/get-llm-text';
 import { CopyMarkdownButton } from '@/components/copy-markdown-button';
@@ -43,7 +44,7 @@ export default async function Page(props: {
         <MDXContent
           components={getMDXComponents({
             // this allows you to link to other pages with relative file paths
-            a: createRelativeLink(source, page),
+            a: createRelativeLink(source, page) as MDXComponents['a'],
           })}
         />
       </DocsBody>

--- a/docsv2/app/(docs)/layout-with-icons.tsx
+++ b/docsv2/app/(docs)/layout-with-icons.tsx
@@ -9,7 +9,7 @@ const docsOptions: DocsLayoutProps = {
   tree: source.pageTree,
   sidebar: {
     tabs: {
-      transform: (option, node) => {
+      transform: (option) => {
         // Add custom icons based on the tab title
         const icons: Record<string, ReactNode> = {
           'Components': <FileText className="w-4 h-4" />,

--- a/docsv2/components/status-monitor.tsx
+++ b/docsv2/components/status-monitor.tsx
@@ -6,7 +6,7 @@ import { Tracker } from './tremor/tracker';
 
 // Simple seeded random number generator for consistent server/client rendering
 const seededRandom = (seed: number) => {
-  let x = Math.sin(seed) * 10000;
+  const x = Math.sin(seed) * 10000;
   return x - Math.floor(x);
 };
 

--- a/docsv2/content/docs/partials/features-cards.mdx
+++ b/docsv2/content/docs/partials/features-cards.mdx
@@ -2,35 +2,44 @@
 title: Features Cards
 ---
 
+import {
+  Columns3 as Columns3Icon,
+  Eye as EyeIcon,
+  PlugZap as PlugZapIcon,
+  Globe as GlobeIcon,
+  ShieldCheck as ShieldCheckIcon,
+} from 'lucide-react';
+import { WorkflowModelCount as WorkflowModelCountPartial } from '../../../components/workflow-model-count';
+
 <Cards>
   <Card 
     title="Compare models side-by-side"
     description="Explore the playground to compare different models and see their outputs in real time."
     href="/docs/playground"
-    icon={<Columns3 />}
+    icon={<Columns3Icon />}
   />
   <Card 
     title="Observability"
     description="Observe how your agent is performing with detailed logs and analytics."
     href="/docs/observability"
-    icon={<Eye />}
+    icon={<EyeIcon />}
   />
   <Card 
     title="Try new models"
-    description={<>Connect to <WorkflowModelCount /> models instantly without any setup or configuration.</>}
+    description={<>Connect to <WorkflowModelCountPartial /> models instantly without any setup or configuration.</>}
     href="/docs/inference/models"
-    icon={<PlugZap />}
+    icon={<PlugZapIcon />}
   />
   <Card 
     title="Tools"
     description="Enable web search and browsing for your agent to access up-to-date information."
     href="/docs/agents/tools"
-    icon={<Globe />}
+    icon={<GlobeIcon />}
   />
   <Card 
     title="100% uptime"
     description="Learn more about how WorkflowAI ensures your agents are always available and reliable."
     href="/docs/inference/reliability"
-    icon={<ShieldCheck />}
+    icon={<ShieldCheckIcon />}
   />
 </Cards> 

--- a/docsv2/content/docs/partials/troubleshooting.mdx
+++ b/docsv2/content/docs/partials/troubleshooting.mdx
@@ -2,22 +2,24 @@
 title: Troubleshooting
 ---
 
-<Accordions type="single">
-  <Accordion title="I don't see my agent in the dashboard" id="agent-dashboard">
+import { Accordions as AccordionsPartial, Accordion as AccordionPartial } from 'fumadocs-ui/components/accordion';
+
+<AccordionsPartial type="single">
+  <AccordionPartial title="I don't see my agent in the dashboard" id="agent-dashboard">
     - Check that your agent has made at least one request through WorkflowAI. The agent will appear in the dashboard after its first successful request.
     - Verify there are no errors in your application logs when making the API request.
     - Ensure you're using the correct API key and base URL (`https://run.workflowai.com/v1`).
-  </Accordion>
+  </AccordionPartial>
 
-  <Accordion title="I'm using OpenAI for multiple endpoints (responses API, embeddings, audio, etc.)" id="multiple-endpoints">
+  <AccordionPartial title="I'm using OpenAI for multiple endpoints (responses API, embeddings, audio, etc.)" id="multiple-endpoints">
     If you are using OpenAI for multiple endpoints in your application:
     - **Only modify the client used for `chat/completions` requests** to point to WorkflowAI
     - **Keep using the standard OpenAI client** for all other endpoints (embeddings, Responses API, audio transcriptions, etc.)
 
     WorkflowAI only supports the `chat/completions` endpoint, so other OpenAI functionality should continue using the standard OpenAI client.
-  </Accordion>
+  </AccordionPartial>
 
-  <Accordion title="What parameters (`stream`, `temperature`, `max_tokens`, etc.) are supported?" id="supported-parameters">
+  <AccordionPartial title="What parameters (`stream`, `temperature`, `max_tokens`, etc.) are supported?" id="supported-parameters">
     See the [reference/parameters.md](reference/parameters.md) documentation for a full list of supported parameters.
-  </Accordion>
-</Accordions> 
+  </AccordionPartial>
+</AccordionsPartial>

--- a/docsv2/mdx-components.tsx
+++ b/docsv2/mdx-components.tsx
@@ -10,5 +10,5 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     ...TabsComponents,
     img: (props) => <ImageZoom {...(props as any)} />,
     ...components,
-  };
+  } as MDXComponents;
 }


### PR DESCRIPTION
## Summary
- revert to Google-hosted Inter font
- cast createRelativeLink return type instead of using `any`

## Testing
- `yarn workspace docs lint` *(fails: Couldn't find a script named "lint")*
- `yarn workspace docs build` *(fails to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684b69d328dc832e8785bc067a1ba3a4