### PR TITLE
Fix instructions overflow on versions page

### DIFF
--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/versions/VersionEntryContainerProperties.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/versions/VersionEntryContainerProperties.tsx
@@ -41,7 +41,9 @@ export function VersionEntryContainerProperties(props: VersionEntryContainerProp
   return (
     <div className='flex flex-col flex-1 border-l border-gray-200 border-dashed pt-3 pb-3 px-4 gap-3'>
       {!!messages ? (
-        <ProxyMessagesView messages={messages} />
+        <div className='max-h-[calc(100vh-260px)] overflow-y-auto'>
+          <ProxyMessagesView messages={messages} />
+        </div>
       ) : (
         !!instructions && (
           <div className='flex flex-col gap-1.5'>


### PR DESCRIPTION
## Summary
- limit instructions box height and make it scrollable

## Testing
- `yarn prettier-check`
- `yarn workspace workflowai lint`
- `yarn workspace workflowai build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_684c1758ab94833192aaf902666dc3af

Closes: https://linear.app/workflowai/issue/WOR-3497/adding-max-height-for-instructions-on-versions-page