### PR TITLE
Update MCP server API endpoint

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -451,4 +451,4 @@ async def deploy_agent_version(
 
 
 def mcp_http_app():
-    return _mcp.http_app(path="/sse")
+    return _mcp.http_app(path="/")

--- a/api/api/routers/mcp/mcp_server_DOCS.md
+++ b/api/api/routers/mcp/mcp_server_DOCS.md
@@ -23,7 +23,7 @@ For local / dev:
 {
   "mcpServers": {
     "workflowai": {
-      "url": "http://localhost:8000/mcp/sse",
+      "url": "http://localhost:8000/mcp/",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -38,7 +38,7 @@ For staging:
 {
   "mcpServers": {
     "workflowai": {
-      "url": "https://api.workflowai.dev/mcp/sse",
+      "url": "https://api.workflowai.dev/mcp/",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -53,7 +53,7 @@ For prod preview:
 {
   "mcpServers": {
     "workflowai": {
-      "url": "https://workflowai-api-preview.bravewave-364a85ed.eastus.azurecontainerapps.io/mcp/sse",
+      "url": "https://workflowai-api-preview.bravewave-364a85ed.eastus.azurecontainerapps.io/mcp/",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -69,7 +69,7 @@ For production:
 {
   "mcpServers": {
     "workflowai": {
-      "url": "https://api.workflowai.com/mcp/sse",
+      "url": "https://api.workflowai.com/mcp/",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }


### PR DESCRIPTION
The `path` parameter within the `mcp_http_app()` function in `api/api/routers/mcp/mcp_server.py` was updated from `"/sse"` to `"/"`. This change corrects the MCP server's exposed endpoint from `/mcp/sse/` to `/mcp/`, aligning it with the actual HTTP transport used instead of Server-Sent Events (SSE).

Correspondingly, the documentation in `api/api/routers/mcp/mcp_server_DOCS.md` was updated. All instances of `mcp/sse` in example URLs were changed to `mcp/` to reflect the new endpoint path.

This ensures the endpoint name accurately reflects the transport protocol. It is a breaking change for any existing MCP clients configured to use the `/mcp/sse/` path, requiring them to update to `/mcp/`.