### PR TITLE
MCP: remove `request` object.

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -2,7 +2,6 @@ from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_request
-from pydantic import BaseModel, Field
 from starlette.exceptions import HTTPException
 
 from api.dependencies.task_info import TaskTuple
@@ -244,19 +243,25 @@ async def get_agent_versions(
     return await service.list_agent_versions(task_tuple)
 
 
-class SearchRunsByMetadataRequest(BaseModel):
-    agent_id: str = Field(
-        description="The agent ID of the agent to search runs for",
-    )
-    field_queries: list[dict[str, Any]] = Field(
-        description="List of metadata field queries. Each query should have: field_name (string starting with 'metadata.'), operator (string like 'is', 'contains', etc.), values (list of values), and optionally type (string like 'string', 'number', etc.)",
-    )
-    limit: int = Field(default=20, description="Maximum number of results to return")
-    offset: int = Field(default=0, description="Number of results to skip")
-
-
-# @_mcp.tool() WIP
-async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPToolReturn:
+@_mcp.tool()
+async def search_runs_by_metadata(
+    agent_id: Annotated[
+        str,
+        "The agent ID of the agent to search runs for",
+    ],
+    field_queries: Annotated[
+        list[dict[str, Any]],
+        "List of metadata field queries. Each query should have: field_name (string starting with 'metadata.'), operator (string like 'is', 'contains', etc.), values (list of values), and optionally type (string like 'string', 'number', etc.)",
+    ],
+    limit: Annotated[
+        int,
+        "Maximum number of results to return",
+    ] = 20,
+    offset: Annotated[
+        int,
+        "Number of results to skip",
+    ] = 0,
+) -> MCPToolReturn:
     """<when_to_use>
     When the user wants to search agent runs based on metadata values, such as filtering runs by custom metadata fields they've added to their WorkflowAI agent calls.
     </when_to_use>
@@ -285,7 +290,7 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
     <examples>
     Example 1 - Search for runs with specific user_id:
     {
-        "task_id": "email-classifier",
+        "agent_id": "email-classifier",
         "field_queries": [
             {
                 "field_name": "metadata.user_id",
@@ -298,7 +303,7 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
 
     Example 2 - Search for runs in production environment with high priority:
     {
-        "task_id": "data-processor",
+        "agent_id": "data-processor",
         "field_queries": [
             {
                 "field_name": "metadata.environment",
@@ -317,7 +322,7 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
 
     Example 3 - Search for runs that contain specific text in a notes field:
     {
-        "task_id": "content-moderator",
+        "agent_id": "content-moderator",
         "field_queries": [
             {
                 "field_name": "metadata.notes",
@@ -329,7 +334,7 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
 
     Example 4 - Search for runs where a field is empty:
     {
-        "task_id": "task-analyzer",
+        "agent_id": "task-analyzer",
         "field_queries": [
             {
                 "field_name": "metadata.reviewer",
@@ -349,12 +354,12 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
     - Error details if the run failed
     </returns>"""
     service = await get_mcp_service()
-    task_tuple = await get_task_tuple_from_task_id(request.agent_id)
+    task_tuple = await get_task_tuple_from_task_id(agent_id)
     return await service.search_runs_by_metadata(
         task_tuple=task_tuple,
-        field_queries=request.field_queries,
-        limit=request.limit,
-        offset=request.offset,
+        field_queries=field_queries,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -243,7 +243,7 @@ async def get_agent_versions(
     return await service.list_agent_versions(task_tuple)
 
 
-@_mcp.tool()
+# @_mcp.tool() WIP
 async def search_runs_by_metadata(
     agent_id: Annotated[
         str,

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -244,28 +244,6 @@ async def get_agent_versions(
     return await service.list_agent_versions(task_tuple)
 
 
-class AskAIEngineerRequest(BaseModel):
-    agent_schema_id: int | None = Field(
-        description="The schema ID of the user's agent version, if known from model=<agent_id>/<agent_schema_id>/<deployment_environment> when the workflowAI agent is already deployed",
-        default=None,
-    )
-    agent_id: str = Field(
-        description="The id of the user's agent, MUST be passed when the user is asking a question in the context of a specific agent. Example: 'email-filtering-agent' in 'model=email-filtering-agent/gpt-4o-latest'. Pass 'new' when the user wants to create a new agent.",
-    )
-    message: str = Field(
-        description="Your message to the AI engineer about what help you need",
-        default="I need help improving my agent",
-    )
-    user_programming_language: str | None = Field(
-        description="The programming language and integration (if known) used by the user, e.g, Typescript, Python with OpenAI SDK, etc.",
-        default=None,
-    )
-    user_code_extract: str | None = Field(
-        description="The code you are working on to improve the user's agent, if any. Please DO NOT include API keys or other sensitive information.",
-        default=None,
-    )
-
-
 class SearchRunsByMetadataRequest(BaseModel):
     agent_id: str = Field(
         description="The agent ID of the agent to search runs for",
@@ -381,7 +359,28 @@ async def search_runs_by_metadata(request: SearchRunsByMetadataRequest) -> MCPTo
 
 
 @_mcp.tool()
-async def ask_ai_engineer(request: AskAIEngineerRequest) -> MCPToolReturn:
+async def ask_ai_engineer(
+    agent_id: Annotated[
+        str,
+        "The id of the user's agent, MUST be passed when the user is asking a question in the context of a specific agent. Example: 'email-filtering-agent' in 'model=email-filtering-agent/gpt-4o-latest'. Pass 'new' when the user wants to create a new agent.",
+    ],
+    message: Annotated[
+        str,
+        "Your message to the AI engineer about what help you need",
+    ] = "I need help improving my agent",
+    agent_schema_id: Annotated[
+        int | None,
+        "The schema ID of the user's agent version, if known from model=<agent_id>/<agent_schema_id>/<deployment_environment> when the workflowAI agent is already deployed",
+    ] = None,
+    user_programming_language: Annotated[
+        str | None,
+        "The programming language and integration (if known) used by the user, e.g, Typescript, Python with OpenAI SDK, etc.",
+    ] = None,
+    user_code_extract: Annotated[
+        str | None,
+        "The code you are working on to improve the user's agent, if any. Please DO NOT include API keys or other sensitive information.",
+    ] = None,
+) -> MCPToolReturn:
     """
     <when_to_use>
     Most user request about WorkflowAI must be processed by starting a conversation with the AI engineer agent to get insight about the WorkflowAI platform and the user's agents.
@@ -394,11 +393,11 @@ async def ask_ai_engineer(request: AskAIEngineerRequest) -> MCPToolReturn:
     """
     service = await get_mcp_service()
     return await service.ask_ai_engineer(
-        agent_schema_id=request.agent_schema_id,
-        agent_id=request.agent_id,
-        message=request.message,
-        user_programming_language=request.user_programming_language,
-        user_code_extract=request.user_code_extract,
+        agent_schema_id=agent_schema_id,
+        agent_id=agent_id,
+        message=message,
+        user_programming_language=user_programming_language,
+        user_code_extract=user_code_extract,
     )
 
 


### PR DESCRIPTION
@yannbu when using Claude Code with our MCP server, I ran into the following issues:
```
workflowai:ask_ai_engineer (MCP)(request: "{\n  \"agent_id\": \"new\",\n  \"message\": \"How do I create an AI agent? I'm looking
                                  for guidance on the process, best practices, and what I need to know to get started with building
                                  an AI agent on WorkflowAI.\"\n}")
  ⎿  Error: Error calling tool 'ask_ai_engineer': 1 validation error for call[ask_ai_engineer]
     request
       Input should be a valid dictionary or instance of AskAIEngineerRequest [type=model_type, input_value='{\n  "agent_id": 
     "new",\...gent on WorkflowAI."\n}', input_type=str]
         For further information visit https://errors.pydantic.dev/2.11/v/model_type
```

I think the error might be that MCP tool does not allow to pass Pydantic object, but instead want all the fields to be at the "root" of the input.

-----

The `api/api/routers/mcp/mcp_server.py` file was refactored to resolve Pydantic validation errors and ensure consistent parameter handling for MCP tools.

Specifically:
*   The `ask_ai_engineer` function's signature was updated to accept individual `Annotated` parameters (`agent_id`, `message`, `agent_schema_id`, `user_programming_language`, `user_code_extract`) instead of a single `AskAIEngineerRequest` Pydantic model.
    *   The function body was adjusted to pass these individual parameters to the service layer.
    *   The unused `AskAIEngineerRequest` class was removed.
*   The `search_runs_by_metadata` function underwent similar changes:
    *   Its signature was refactored to use individual `Annotated` parameters (`agent_id`, `field_queries`, `limit`, `offset`).
    *   The function body was updated to use these parameters.
    *   The unused `SearchRunsByMetadataRequest` class was removed.

These changes ensure that all MCP tools in the file now consistently use individual `Annotated` parameters, aligning with how the MCP framework passes arguments and resolving the Pydantic validation issues.