### PR TITLE
tool response token limits

### DIFF
--- a/.discussions/mcp-tool-token-limits.md
+++ b/.discussions/mcp-tool-token-limits.md
@@ -20,6 +20,10 @@ We're experiencing issues with MCP (Model Context Protocol) tools returning resp
   - Could we group models by provider/category to reduce redundant information?
   - Should we have separate endpoints for model listing vs. detailed model specs?
   - Can we implement model filtering by provider, capability, or cost tier?
+- **Pierre's Suggestions**:
+  - Should be paginated
+  - Return the models that are most used in WorkflowAI first (prioritize popular models)
+  - Should also include recent models (newly added models might be interesting to users)
 
 ### `list_agents(from_date)`
 - **Current Issue**: Returns 249,108 tokens - extremely large response (10x over limit)
@@ -30,6 +34,10 @@ We're experiencing issues with MCP (Model Context Protocol) tools returning resp
   - Should statistics be optional or computed on-demand?
   - Can we limit the date range for statistics to reduce computation and response size?
   - Should we filter out inactive/archived agents by default?
+- **Pierre's Suggestions**:
+  - Should be paginated
+  - Return active agents first (prioritize agents that are currently being used)
+  - Should also include recently created agents (new agents might need attention/debugging)
 
 ### `fetch_run_details(agent_id, run_id, run_url)`
 - **Potential Issues**: Could return large responses for runs with extensive input/output data

--- a/.discussions/mcp-tool-token-limits.md
+++ b/.discussions/mcp-tool-token-limits.md
@@ -24,6 +24,14 @@ We're experiencing issues with MCP (Model Context Protocol) tools returning resp
   - Should be paginated
   - Return the models that are most used in WorkflowAI first (prioritize popular models)
   - Should also include recent models (newly added models might be interesting to users)
+- **Pierre's Refined Suggestions**:
+  - Should be paginated
+  - Add a `sort_by` parameter to let the MCP client decide ordering:
+    - `popularity` - most used models first
+    - `price` - cheapest models first
+    - `recent` - newly added models first  
+    - `intelligence` - most capable models first
+  - This gives clients control over what they prioritize while keeping responses manageable
 
 ### `list_agents(from_date)`
 - **Current Issue**: Returns 249,108 tokens - extremely large response (10x over limit)
@@ -38,6 +46,13 @@ We're experiencing issues with MCP (Model Context Protocol) tools returning resp
   - Should be paginated
   - Return active agents first (prioritize agents that are currently being used)
   - Should also include recently created agents (new agents might need attention/debugging)
+- **Pierre's Refined Suggestions**:
+  - Should be paginated
+  - Add a `sort_by` parameter to let the MCP client decide ordering:
+    - `active` - currently active agents first
+    - `runs` - agents with most runs first
+    - `recently_created` - newest agents first
+  - This gives clients control over what they prioritize while keeping responses manageable
 
 ### `fetch_run_details(agent_id, run_id, run_url)`
 - **Potential Issues**: Could return large responses for runs with extensive input/output data

--- a/.discussions/mcp-tool-token-limits.md
+++ b/.discussions/mcp-tool-token-limits.md
@@ -1,0 +1,78 @@
+# MCP Tool Response Token Limit Issues
+
+## Problem Statement
+
+We're experiencing issues with MCP (Model Context Protocol) tools returning responses that exceed the maximum allowed token limit of 25,000 tokens when used through Claude code as the MCP client.
+
+## Current Errors
+
+### Observed Issues
+- `workflowai:list_agents(from_date: "2024-12-10T00:00:00Z")`: **249,108 tokens** (10x over limit)
+- `list_available_models`: **32,007 tokens** (1.3x over limit)
+
+## Discussion Points by MCP Tool
+
+### `workflowai:list_agents`
+- **Current Issue**: Returns 249,108 tokens - extremely large response
+- **Discussion Points**:
+  - Should we implement pagination by default?
+  - What filtering options could reduce response size?
+  - Should we limit the number of agents returned per call?
+  - What fields in agent data are essential vs. optional?
+  - Could we implement a "summary" vs "detailed" response mode?
+
+### `list_available_models`
+- **Current Issue**: Returns 32,007 tokens - moderately over limit
+- **Discussion Points**:
+  - Are we returning too much metadata per model?
+  - Should we group models by category/provider?
+  - Could we implement model filtering by capability/type?
+  - What model information is essential for client decision-making?
+  - Should we have separate endpoints for model listing vs. model details?
+
+## General Solution Approaches to Discuss
+
+### Pagination Strategies
+- Cursor-based pagination
+- Offset/limit pagination
+- Page size recommendations
+
+### Response Filtering
+- Field selection (sparse fieldsets)
+- Conditional inclusion of expensive fields
+- Client-specified response formats
+
+### Data Structure Optimization
+- Removing redundant information
+- Compressing common patterns
+- Using references instead of full objects
+
+### Alternative Approaches
+- Streaming responses
+- Multi-call patterns with smaller chunks
+- Caching strategies for frequently requested data
+
+## Questions for Team Discussion
+
+1. **Backwards Compatibility**: How do we handle existing clients when we change response structures?
+
+2. **Default Behavior**: Should tools default to minimal responses and require explicit requests for detailed data?
+
+3. **Error Handling**: How should tools behave when a response would exceed limits? Truncate? Return error? Auto-paginate?
+
+4. **Client Guidance**: What documentation/examples should we provide to help MCP clients use tools efficiently?
+
+5. **Monitoring**: Should we track token usage patterns to proactively identify tools that might hit limits?
+
+## Next Steps
+
+- [ ] Analyze each MCP tool's typical response sizes
+- [ ] Define token budgeting guidelines for tool responses
+- [ ] Prototype pagination/filtering solutions for high-volume tools
+- [ ] Create usage guidelines for MCP clients
+- [ ] Implement token usage monitoring
+
+---
+
+*Created: December 2024*
+*Status: Initial discussion - awaiting team input*


### PR DESCRIPTION
A new directory `.discussions` was created at the root to house team discussions.

A new file, `.discussions/mcp-tool-token-limits.md`, was then created within this directory. This file serves as a discussion document to brainstorm solutions for MCP tool responses exceeding the 25,000 token limit.

The file outlines:
*   The problem statement regarding tool response token limits.
*   Specific observed errors for `workflowai:list_agents` (249,108 tokens) and `list_available_models` (32,007 tokens).
*   Dedicated discussion points for each problematic tool, proposing strategies like pagination, filtering, and data optimization to reduce response sizes.
*   General solution approaches, key questions for team discussion (e.g., backwards compatibility, default behavior), and next steps to guide the brainstorming process.

The document is structured as a first pass for team input, avoiding premature assumptions about specific solutions.