### PR TITLE
[WOR-4977] Only show the Types selector in Proxy Playgrounds if hovering

### DIFF
--- a/client/src/components/ObjectViewer/FieldViewer.tsx
+++ b/client/src/components/ObjectViewer/FieldViewer.tsx
@@ -127,6 +127,8 @@ export function FieldViewer(props: FieldViewerProps) {
   const columnLayout = isExpandable || !rest.showTypes;
   const isParentArray = arrayIndex !== undefined;
 
+  const [isHovering, setIsHovering] = useState(false);
+
   const fieldViewerLabel = (
     <FieldViewerLabel
       textColor={textColorToUse}
@@ -153,10 +155,10 @@ export function FieldViewer(props: FieldViewerProps) {
       showDescriptionPopover={rest.showDescriptionPopover !== false}
       onTypeChange={onTypeChange}
       schemaRefName={schemaRefName}
+      isHoveringOverValue={isHovering}
     />
   );
 
-  const [isHovering, setIsHovering] = useState(false);
   const [evaluationEditOn, setEvaluationEditOn] = useState(false);
 
   const showExamples = rest.showDescriptionExamples === 'all';
@@ -167,7 +169,11 @@ export function FieldViewer(props: FieldViewerProps) {
         <ListItemSideline arrayIndex={arrayIndex} isRoot={isRoot} isLast={isLast} showTypes={!!rest.showTypes} />
         <div className='px-3 flex items-start w-full'>
           {columnLayout ? (
-            <div className='flex-1 flex flex-col w-full items-start'>
+            <div
+              className='flex-1 flex flex-col w-full items-start'
+              onMouseEnter={() => setIsHovering(true)}
+              onMouseLeave={() => setIsHovering(false)}
+            >
               {fieldViewerLabel}
               {rest.showDescriptionExamples && (
                 <FieldDescriptionExamples

--- a/client/src/components/ObjectViewer/FieldViewerLabel.tsx
+++ b/client/src/components/ObjectViewer/FieldViewerLabel.tsx
@@ -1,7 +1,7 @@
 import { DismissFilled, ErrorCircle24Filled, List16Regular } from '@fluentui/react-icons';
 import { cx } from 'class-variance-authority';
 import { PlusCircle, Trash2 } from 'lucide-react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/Badge';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/HoverCard';
 import { SimpleTooltip } from '@/components/ui/Tooltip';
@@ -40,6 +40,7 @@ type FieldViewerLabelProps = {
   showDescriptionPopover: boolean;
   onTypeChange?: (keyPath: string, newType: string) => void;
   schemaRefName: string | undefined;
+  isHoveringOverValue?: boolean;
 };
 
 export function FieldViewerLabel(props: FieldViewerLabelProps) {
@@ -67,6 +68,7 @@ export function FieldViewerLabel(props: FieldViewerLabelProps) {
     showDescriptionPopover,
     onTypeChange,
     schemaRefName,
+    isHoveringOverValue,
   } = props;
 
   // This is a side effect that updates the position of the field key in the parent component
@@ -90,16 +92,21 @@ export function FieldViewerLabel(props: FieldViewerLabelProps) {
   }, [isArrayObject, showTypes, editable, fieldKey, onlyShowDescriptionsAndExamplesAndHideTypes]);
   const NullToggleIcon = isNull ? PlusCircle : Trash2;
 
+  const [isHoveringOverLabel, setIsHoveringOverLabel] = useState(false);
+
   const showTypeChangeButtons = useMemo(() => {
-    return (
+    if (
       !!onTypeChange &&
       (subSchemaFieldType === 'undefined' ||
         subSchemaFieldType === 'audio' ||
         subSchemaFieldType === 'document' ||
         subSchemaFieldType === 'image' ||
         subSchemaFieldType === 'string')
-    );
-  }, [onTypeChange, subSchemaFieldType]);
+    ) {
+      return isHoveringOverLabel || isHoveringOverValue;
+    }
+    return false;
+  }, [onTypeChange, subSchemaFieldType, isHoveringOverLabel, isHoveringOverValue]);
 
   const realFieldType: FieldType | undefined = useMemo(() => {
     if (schemaRefName) {
@@ -121,6 +128,8 @@ export function FieldViewerLabel(props: FieldViewerLabelProps) {
         'w-full': isArrayObject || !!onTypeChange,
       })}
       ref={fieldRef}
+      onMouseEnter={() => setIsHoveringOverLabel(true)}
+      onMouseLeave={() => setIsHoveringOverLabel(false)}
     >
       <div
         className={cx(


### PR DESCRIPTION
Closes:
https://linear.app/workflowai/issue/WOR-4977/only-show-the-types-selector-in-proxy-playgrounds-if-hovering

Screenshot:
<img width="657" alt="Screenshot 2025-06-17 at 10 42 02 AM" src="https://github.com/user-attachments/assets/ce7e2b3e-1c06-4253-871d-3b07ec852ffc" />
