### PR TITLE
Check and deprecate GPT-4.5 preview model

### DIFF
--- a/api/core/domain/models/model_datas_mapping.py
+++ b/api/core/domain/models/model_datas_mapping.py
@@ -167,26 +167,9 @@ def _raw_model_data() -> dict[Model, ModelData | LatestModel | DeprecatedModel]:
             supports_tool_calling=True,
             fallback=_openai_fallback("cheapest", context_exceeded="no"),
         ),
-        Model.GPT_45_PREVIEW_2025_02_27: ModelData(
-            display_name="GPT-4.5-preview (2025-02-27)",
-            supports_json_mode=True,
-            supports_input_image=True,
-            supports_input_pdf=False,
-            supports_input_audio=False,
-            supports_structured_output=True,
-            max_tokens_data=MaxTokensData(
-                max_tokens=128_000,
-                max_output_tokens=16_384,
-                source="https://platform.openai.com/docs/models",
-            ),
-            icon_url="https://workflowai.blob.core.windows.net/workflowai-public/openai.svg",
-            release_date=date(2025, 2, 27),
-            quality_data=QualityData(mmlu=85.10, gpqa=71.40),
-            latest_model=Model.GPT_4O_LATEST,
-            provider_name=DisplayedProvider.OPEN_AI.value,
-            supports_tool_calling=True,
+        Model.GPT_45_PREVIEW_2025_02_27: DeprecatedModel(
+            replacement_model=Model.GPT_41_LATEST,
             aliases=["gpt-4.5-preview"],
-            fallback=_openai_fallback("expensive"),
         ),
         Model.GPT_4O_2024_05_13: DeprecatedModel(replacement_model=Model.GPT_4O_2024_11_20),
         Model.GPT_4_TURBO_2024_04_09: DeprecatedModel(

--- a/api/core/domain/models/model_provider_datas_mapping.py
+++ b/api/core/domain/models/model_provider_datas_mapping.py
@@ -386,14 +386,6 @@ OPENAI_PROVIDER_DATA: ProviderDataByModel = {
             source="https://openai.com/api/pricing/",
         ),
     ),
-    Model.GPT_45_PREVIEW_2025_02_27: ModelProviderData(
-        text_price=TextPricePerToken(
-            prompt_cost_per_token=75 * ONE_MILLION_TH,
-            prompt_cached_tokens_discount=0.5,
-            completion_cost_per_token=150 * ONE_MILLION_TH,
-            source="https://openai.com/api/pricing/",
-        ),
-    ),
     Model.GPT_4O_MINI_2024_07_18: ModelProviderData(
         text_price=TextPricePerToken(
             prompt_cost_per_token=0.15 * ONE_MILLION_TH,


### PR DESCRIPTION
The `gpt-4.5-preview` model was deprecated in the codebase to align with OpenAI's announcement.

*   In `api/core/domain/models/model_datas_mapping.py`:
    *   The `Model.GPT_45_PREVIEW_2025_02_27` entry was updated from `ModelData` to `DeprecatedModel`.
    *   Its `replacement_model` was set to `Model.GPT_41_LATEST` to ensure API calls using the deprecated model are automatically redirected.
    *   The alias `"gpt-4.5-preview"` was retained for backward compatibility.
*   In `api/core/domain/models/model_provider_datas_mapping.py`:
    *   The `Model.GPT_45_PREVIEW_2025_02_27` entry was removed from `OPENAI_PROVIDER_DATA`. This was done to follow observed patterns where provider data entries for deprecated models are also removed.

These changes ensure that the system handles the deprecation gracefully, redirecting traffic to a supported model while maintaining compatibility for existing API calls.