### PR TITLE
Improve API error message for model lookup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "None",
+  "python.languageServer": "Pylance",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "Pylance",
+  "python.languageServer": "None",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/api/api/routers/openai_proxy/_openai_proxy_handler.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler.py
@@ -468,7 +468,7 @@ class OpenAIProxyHandler:
     @classmethod
     async def missing_model_error(cls, model: str | None, prefix: str = ""):
         _check_lineup = f"Check the lineup 👉 {WORKFLOWAI_APP_URL}/models ({MODEL_COUNT} models)"
-        _curl_command = "curl http://run.workflowai.com/v1/models"
+        _curl_command = "curl https://run.workflowai.com/v1/models"
         if not model:
             return BadRequestError(
                 f"""Empty model

--- a/api/api/routers/openai_proxy/_openai_proxy_handler.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler.py
@@ -468,15 +468,18 @@ class OpenAIProxyHandler:
     @classmethod
     async def missing_model_error(cls, model: str | None, prefix: str = ""):
         _check_lineup = f"Check the lineup 👉 {WORKFLOWAI_APP_URL}/models ({MODEL_COUNT} models)"
+        _curl_command = "curl http://run.workflowai.com/v1/models"
         if not model:
             return BadRequestError(
                 f"""Empty model
-{_check_lineup}""",
+{_check_lineup}
+To list all models programmatically: {_curl_command}""",
             )
 
         components = [
             f"Unknown {prefix}model: {model}",
             _check_lineup,
+            f"To list all models programmatically: {_curl_command}",
         ]
         if suggested := await ModelsService.suggest_model(model):
             components.insert(1, f"Did you mean {suggested}?")

--- a/api/api/routers/openai_proxy/_openai_proxy_handler.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler.py
@@ -467,7 +467,7 @@ class OpenAIProxyHandler:
 
     @classmethod
     async def missing_model_error(cls, model: str | None, prefix: str = ""):
-        _check_lineup = f"Check the lineup 👉 {WORKFLOWAI_APP_URL}/models ({MODEL_COUNT} models)"
+        _check_lineup = f"Check the lineup 👉 {WORKFLOWAI_APP_URL} ({MODEL_COUNT} models)"
         _curl_command = "curl https://run.workflowai.com/v1/models"
         if not model:
             return BadRequestError(


### PR DESCRIPTION
The `missing_model_error` method in `api/api/routers/openai_proxy/_openai_proxy_handler.py` was updated to enhance model not found error messages.

*   A `_curl_command` variable was introduced, set to `"curl https://run.workflowai.com/v1/models"`.
*   For empty model errors, the curl command was appended to the existing message, guiding users to list models programmatically.
*   For unknown model errors, the curl command was added as a new component in the error message, appearing after the model lineup link.

This change provides users encountering model-related errors with a direct, programmatic method to discover available models, complementing the existing web interface link.