### PR TITLE
Update error message for template formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "None",
+  "python.languageServer": "Pylance",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "Pylance",
+  "python.languageServer": "None",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/api/api/routers/agents_v1.py
+++ b/api/api/routers/agents_v1.py
@@ -188,5 +188,9 @@ async def extract_template(request: ExtractTemplateRequest) -> ExtractTemplateRe
         else:
             raise BadRequestError("Either template or messages must be provided")
     except InvalidTemplateError as e:
-        raise BadRequestError(f"Invalid template: {e.message}", details=e.serialize_details())
+        # Help users by reminding them that our templates follow Jinja2 syntax
+        raise BadRequestError(
+            f"Invalid template: {e.message}. Templates must use Jinja2 formatting.",
+            details=e.serialize_details(),
+        )
     return ExtractTemplateResponse(json_schema=json_schema, last_templated_index=last_templated_index)

--- a/api/api/routers/agents_v1_test.py
+++ b/api/api/routers/agents_v1_test.py
@@ -38,7 +38,7 @@ class TestExtractTemplate:
             "error": {
                 "code": "bad_request",
                 "status_code": 400,
-                "message": "Invalid template: unexpected '}'",
+                "message": "Invalid template: unexpected '}'. Templates must use Jinja2 formatting.",
                 "details": {
                     "line_number": 1,
                     "unexpected_char": "}",

--- a/api/api/routers/openai_proxy/_openai_proxy_handler.py
+++ b/api/api/routers/openai_proxy/_openai_proxy_handler.py
@@ -116,7 +116,10 @@ class OpenAIProxyHandler:
         try:
             input_schema, last_templated_index = cls._json_schema_from_input(messages, input)
         except InvalidTemplateError as e:
-            raise BadRequestError(f"Invalid template: {e.message}", details=e.serialize_details())
+            raise BadRequestError(
+                f"Invalid template: {e.message}. Templates must use Jinja2 formatting.",
+                details=e.serialize_details(),
+            )
 
         if response_format:
             match response_format.type:


### PR DESCRIPTION
Template-related error messages were updated to provide clearer guidance on expected formatting.

*   In `api/api/routers/agents_v1.py` and `api/api/routers/openai_proxy/_openai_proxy_handler.py`, the `BadRequestError` message, raised upon an `InvalidTemplateError`, was extended.
    *   The updated message now includes "Templates must use Jinja2 formatting."
    *   This change aims to assist users in understanding and correcting templating errors by explicitly stating the required syntax.
*   The corresponding test case in `api/api/routers/agents_v1_test.py` was updated.
    *   The expected error response string now reflects the addition of the Jinja2 formatting hint, ensuring test coverage for the new message.