### PR TITLE
Feature/structured model supports

### DIFF
--- a/api/api/_standard_model_response.py
+++ b/api/api/_standard_model_response.py
@@ -160,7 +160,7 @@ class StandardModelResponse(BaseModel):
             return cls(
                 id=id,
                 created=int(datetime.datetime.combine(model.release_date, datetime.time(0, 0)).timestamp()),
-                owned_by="WorkflowAI",
+                owned_by="WorkflowAI",  # we are not exposing what underlying providers are used
                 display_name=model.display_name,
                 icon_url=model.icon_url,
                 supports=ModelSupports(


### PR DESCRIPTION
sorry my internal testing are not working yet (don't have mongodb setup) so I'll make this PR as a draft.
@guillaq thank you! 

the main goals of this API are:
- use a Pydantic object to represent the `support` object returned in `/v1/models`
- remove fields that are not meant to be exposed via `/v1/models`, for example

```
"support_system_messages":true,"structured_output":true,"support_input_schema":true
```

@guillaq if Jacek needs access to these fields, we need another API endpoint I think, or at least a query parameter on `/v1/models` (probably not exposed publicly). 