### PR TITLE
Sanitize model router

### DIFF
--- a/api/api/main_test.py
+++ b/api/api/main_test.py
@@ -162,7 +162,7 @@ class TestModelsEndpoint:
     async def test_models_endpoint_no_auth(self, test_api_client: AsyncClient, mock_tenant_dep: Mock):
         # Making sure we raise if the tenant dep is called
         mock_tenant_dep.side_effect = ValueError("test")
-        res = await test_api_client.get("/v1/models?raw=true")
+        res = await test_api_client.get("/v1/models/ids")
         assert res.status_code == 200, "Expected /models endpoint to be accessible without authentication"
 
         # Add some basic checks to ensure the response contains expected data
@@ -198,7 +198,7 @@ class TestModelsEndpoint:
     async def test_models_endpoint_order_check(self, test_api_client: AsyncClient, mock_tenant_dep: Mock):
         # Making sure we raise if the tenant dep is called
         mock_tenant_dep.side_effect = ValueError("test")
-        res = await test_api_client.get("/v1/models?raw=true")
+        res = await test_api_client.get("/v1/models/ids")
         assert res.status_code == 200, "Expected /models endpoint to be accessible without authentication"
 
         # Add some basic checks to ensure the response contains expected data

--- a/api/api/routers/models_router.py
+++ b/api/api/routers/models_router.py
@@ -1,10 +1,17 @@
 import datetime
-from typing import Any, Literal
+from collections.abc import Iterator
+from typing import Literal, Self
 
+from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
-from core.domain.models.model_data import FinalModelData
+from core.domain.models import Model as ModelID
+from core.domain.models.model_data import FinalModelData, LatestModel, MaxTokensData
 from core.domain.models.model_data_supports import ModelDataSupports
+from core.domain.models.model_datas_mapping import MODEL_DATAS
+from core.domain.models.model_provider_data import ModelProviderData
+
+router = APIRouter(prefix="/v1/models")
 
 
 class SupportsModality(BaseModel):
@@ -45,6 +52,31 @@ class ModelSupports(BaseModel):
         description="Whether the model supports temperature. If false, the temperature parameter will be ignored.",
     )
 
+    @classmethod
+    def from_domain(cls, model: ModelDataSupports) -> Self:
+        return cls(
+            input=SupportsModality(
+                image=model.supports_input_image,
+                audio=model.supports_input_audio,
+                pdf=model.supports_input_pdf,
+                # TODO: we need to overhaul the model data to
+                # add a proper support field for input test
+                # See https://linear.app/workflowai/issue/WOR-4926/sanitize-model-supports-to-include-temperature-and-other-parameters
+                text=not model.supports_audio_only,
+            ),
+            output=SupportsModality(
+                image=model.supports_output_image,
+                audio=False,
+                pdf=False,
+                text=model.supports_output_text,
+            ),
+            parallel_tool_calls=model.supports_parallel_tool_calls,
+            tools=model.supports_tool_calling,
+            # TODO: see https://linear.app/workflowai/issue/WOR-4926/sanitize-model-supports-to-include-temperature-and-other-parameters
+            top_p=True,
+            temperature=True,
+        )
+
 
 class ModelPricing(BaseModel):
     """Pricing information for model usage in USD per token."""
@@ -55,6 +87,13 @@ class ModelPricing(BaseModel):
     output_token_usd: float = Field(
         description="Cost per output token in USD.",
     )
+
+    @classmethod
+    def from_domain(cls, model: ModelProviderData) -> Self:
+        return cls(
+            input_token_usd=model.text_price.prompt_cost_per_token,
+            output_token_usd=model.text_price.completion_cost_per_token,
+        )
 
 
 class ModelReasoning(BaseModel):
@@ -89,6 +128,13 @@ class ModelContextWindow(BaseModel):
     max_output_tokens: int = Field(
         description="The maximum number of tokens that the model can output.",
     )
+
+    @classmethod
+    def from_domain(cls, model: MaxTokensData) -> Self:
+        return cls(
+            max_tokens=model.max_tokens,
+            max_output_tokens=model.max_output_tokens or model.max_tokens,
+        )
 
 
 class Model(BaseModel):
@@ -131,51 +177,51 @@ class Model(BaseModel):
         description="Context window and output token limits for the model.",
     )
 
+    @classmethod
+    def from_domain(cls, id: str, model: FinalModelData) -> Self:
+        provider_data = model.providers[0][1]
+        return cls(
+            id=id,
+            created=int(datetime.datetime.combine(model.release_date, datetime.time(0, 0)).timestamp()),
+            owned_by="WorkflowAI",
+            display_name=model.display_name,
+            icon_url=model.icon_url,
+            supports=ModelSupports.from_domain(model),
+            pricing=ModelPricing.from_domain(provider_data),
+            release_date=model.release_date,
+            reasoning=None,
+            context_window=ModelContextWindow.from_domain(model.max_tokens_data),
+        )
 
-# TODO: use Model above instead of ModelItem
-class StandardModelResponse(BaseModel):
-    """A model response compatible with the OpenAI API"""
 
+class ModelResponse(BaseModel):
     object: Literal["list"] = "list"
 
-    class ModelItem(BaseModel):
-        id: str
-        object: Literal["model"] = "model"
-        created: int
-        owned_by: str
-        display_name: str
-        icon_url: str
-        supports: dict[str, Any]
+    data: list[Model]
 
-        class Pricing(BaseModel):
-            input_token_usd: float
-            output_token_usd: float
 
-        pricing: Pricing
+def _model_data_iterator() -> Iterator[Model]:
+    for model in ModelID:
+        data = MODEL_DATAS[model]
+        if isinstance(data, LatestModel):
+            yield Model.from_domain(model.value, MODEL_DATAS[data.model])  # pyright: ignore [reportArgumentType]
+        elif isinstance(data, FinalModelData):
+            yield Model.from_domain(model.value, data)
+        else:
+            # Skipping deprecated models
+            continue
 
-        release_date: datetime.date
 
-        @classmethod
-        def from_model_data(cls, id: str, model: FinalModelData):
-            provider_data = model.providers[0][1]
-            return cls(
-                id=id,
-                created=int(datetime.datetime.combine(model.release_date, datetime.time(0, 0)).timestamp()),
-                owned_by=model.provider_name,
-                display_name=model.display_name,
-                icon_url=model.icon_url,
-                supports={
-                    k.removeprefix("supports_"): v
-                    for k, v in model.model_dump(
-                        mode="json",
-                        include=set(ModelDataSupports.model_fields.keys()),
-                    ).items()
-                },
-                pricing=cls.Pricing(
-                    input_token_usd=provider_data.text_price.prompt_cost_per_token,
-                    output_token_usd=provider_data.text_price.completion_cost_per_token,
-                ),
-                release_date=model.release_date,
-            )
+@router.get("")
+async def list_models() -> ModelResponse:
+    return ModelResponse(data=list(_model_data_iterator()))
 
-    data: list[ModelItem]
+
+# Because the run and api containers are deployed at different times,
+# the run container must be the source of truth for available models, otherwise
+# the API might believe that some models are available when they are not.
+@router.get("/ids")
+async def list_model_ids() -> list[str]:
+    # No need to filter anything here as the raw models will not be exposed
+    # The api container will filter the models based on the task schema
+    return list(ModelID)

--- a/api/api/services/models.py
+++ b/api/api/services/models.py
@@ -86,7 +86,7 @@ class ModelsService:
     async def _available_models_from_run_endpoint(cls) -> list[Model]:
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"{WORKFLOWAI_RUN_URL}/v1/models?raw=true")
+                response = await client.get(f"{WORKFLOWAI_RUN_URL}/v1/models/ids")
                 response.raise_for_status()
                 model_json = response.json()
 

--- a/api/tests/component/models/models_test.py
+++ b/api/tests/component/models/models_test.py
@@ -9,7 +9,7 @@ from tests.component.common import IntegrationTestClient, task_schema_url_v1
 @pytest.fixture(autouse=True)
 def return_503_from_models_endpoint(test_client: IntegrationTestClient):
     # Making sure the call to the models endpoint fail
-    test_client.httpx_mock.add_response(url=re.compile(r".*/v1/models\?raw=true$"), status_code=503, is_reusable=True)
+    test_client.httpx_mock.add_response(url=re.compile(r".*/v1/models/ids$"), status_code=503, is_reusable=True)
 
 
 @pytest.mark.parametrize("is_authenticated", [True, False])


### PR DESCRIPTION
Supersedes https://github.com/WorkflowAI/WorkflowAI/pull/499

- updates /v1/models to use the new model response that is a full pydantic object
- separates the openai compatible endpoint from the "raw" endpoint to better use fastapi doc. Raw endpoint becomes `/v1/models/ids`
- separate the models logic to its own router 