### PR TITLE
Add temporary API key forwarding tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "None",
+  "python.languageServer": "Pylance",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "Pylance",
+  "python.languageServer": "None",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -492,5 +492,32 @@ async def deploy_agent_version(
     )
 
 
+@_mcp.tool()
+async def create_api_key() -> MCPToolReturn:
+    """<when_to_use>
+    When the user wants to get their API key for WorkflowAI. This is a temporary tool that returns the API key that was used to authenticate the current request.
+    </when_to_use>
+    <returns>
+    Returns the API key that was used to authenticate the current MCP request.
+    </returns>"""
+    request = get_http_request()
+
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return MCPToolReturn(
+            success=False,
+            error="No Authorization header found or invalid format",
+        )
+
+    # Extract the API key from "Bearer <key>"
+    api_key = auth_header.split(" ")[1]
+
+    return MCPToolReturn(
+        success=True,
+        data={"api_key": api_key},
+        messages=["API key retrieved successfully"],
+    )
+
+
 def mcp_http_app():
     return _mcp.http_app(path="/")

--- a/api/tests/integration/mcp/mcp_test.py
+++ b/api/tests/integration/mcp/mcp_test.py
@@ -58,6 +58,7 @@ _WAI_TOOLS = [
     "get_agent_versions",
     "ask_ai_engineer",
     "deploy_agent_version",
+    "create_api_key",
 ]
 
 


### PR DESCRIPTION
A new `create_api_key` tool was added to `api/api/routers/mcp/mcp_server.py`.

*   The tool is an asynchronous function that accesses the current HTTP request.
*   It extracts the API key from the `Authorization: Bearer <key>` header.
*   The extracted key is returned within an `MCPToolReturn` object, or an error is returned if the header is missing or malformed.
*   This tool serves as a temporary mechanism to return the API key used for authentication, rather than creating a new one.

To integrate the new tool into the testing framework, `"create_api_key"` was added to the `_WAI_TOOLS` list in `api/tests/integration/mcp/mcp_test.py`.