### PR TITLE
Add metadata to RunV1 object

### DIFF
--- a/api/api/routers/runs_v1.py
+++ b/api/api/routers/runs_v1.py
@@ -97,6 +97,11 @@ class _BaseRunV1(BaseModel):
         description="A signed token that can be used to post feedback from a client side application",
     )
 
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description="A user set metadata key / value. Keys are not searchable.",
+    )
+
 
 class RunItemV1(_BaseRunV1):
     task_input_preview: str = Field(description="A preview of the input data")
@@ -205,6 +210,7 @@ class RunV1(_BaseRunV1):
             ),
             feedback_token=feedback_token,
             conversation_id=run.conversation_id,
+            metadata=run.metadata,
         )
 
 
@@ -231,7 +237,7 @@ async def get_run(
     runs_service: RunsServiceDep,
     feedback_token_generator: RunFeedbackGeneratorDep,
 ) -> RunV1:
-    run = await runs_service.run_by_id(task_tuple, run_id)
+    run = await runs_service.run_by_id(task_tuple, run_id, exclude={"llm_completions"})
     return RunV1.from_domain_task_run(run, feedback_token_generator(run.id))
 
 

--- a/api/api/routers/runs_v1.py
+++ b/api/api/routers/runs_v1.py
@@ -97,11 +97,6 @@ class _BaseRunV1(BaseModel):
         description="A signed token that can be used to post feedback from a client side application",
     )
 
-    metadata: dict[str, Any] | None = Field(
-        default=None,
-        description="A user set metadata key / value. Keys are not searchable.",
-    )
-
 
 class RunItemV1(_BaseRunV1):
     task_input_preview: str = Field(description="A preview of the input data")
@@ -185,6 +180,11 @@ class RunV1(_BaseRunV1):
     )
 
     conversation_id: str | None
+
+    metadata: dict[str, Any] | None = Field(
+        description="Combination of user defined metadata passed to the completion request, and system metadata "
+        "added by WorkflowAI",
+    )
 
     @classmethod
     def from_domain_task_run(cls, run: AgentRun, feedback_token: str):

--- a/api/api/routers/runs_v1.py
+++ b/api/api/routers/runs_v1.py
@@ -184,6 +184,7 @@ class RunV1(_BaseRunV1):
     # TODO: add details field that contains part of the internal metadata
     # see https://linear.app/workflowai/issue/WOR-5044/fetch-run-details-mcp-tool-missing-deployment-environment-information#comment-d84e92a4
 
+    # TODO: Reference to documentation page about metadata: [URL will change soon]
     metadata: dict[str, Any] | None = Field(
         description="User defined metadata passed to the completion request",
     )

--- a/api/api/routers/runs_v1.py
+++ b/api/api/routers/runs_v1.py
@@ -181,10 +181,11 @@ class RunV1(_BaseRunV1):
 
     conversation_id: str | None
 
+    # TODO: add details field that contains part of the internal metadata
+    # see https://linear.app/workflowai/issue/WOR-5044/fetch-run-details-mcp-tool-missing-deployment-environment-information#comment-d84e92a4
+
     metadata: dict[str, Any] | None = Field(
-        description="Combination of user defined metadata passed to the completion request and metadata "
-        "automatically added by WorkflowAI. WorkflowAI metadata fields are prefixed with `workflowai.` and add "
-        "details about the run, for example which providers were used during the run.",
+        description="User defined metadata passed to the completion request",
     )
 
     @classmethod

--- a/api/api/routers/runs_v1.py
+++ b/api/api/routers/runs_v1.py
@@ -182,8 +182,9 @@ class RunV1(_BaseRunV1):
     conversation_id: str | None
 
     metadata: dict[str, Any] | None = Field(
-        description="Combination of user defined metadata passed to the completion request, and system metadata "
-        "added by WorkflowAI",
+        description="Combination of user defined metadata passed to the completion request and metadata "
+        "automatically added by WorkflowAI. WorkflowAI metadata fields are prefixed with `workflowai.` and add "
+        "details about the run, for example which providers were used during the run.",
     )
 
     @classmethod

--- a/api/api/routers/runs_v1_test.py
+++ b/api/api/routers/runs_v1_test.py
@@ -31,9 +31,9 @@ class TestSearchTaskRunsRequestQuery:
 
 
 class TestLatestRun:
-    # Making sure the mock happens after the test_api_client is created
-    @pytest.fixture(autouse=True)
-    def returned_run(self, test_api_client: AsyncClient, mock_storage: Mock):
+    # test_api_client is in the arg to be sure the mock happens after the test_api_client is created
+    @pytest.fixture()
+    def returned_run(test_api_client: Any, mock_storage: Mock):
         run = task_run_ser(id=str(uuid7()), task_uid=1, task_schema_id=1, status="success")
         mock_storage.task_runs.fetch_task_run_resources.return_value = mock_aiter(run)
         mock_storage.tasks.get_task_info.return_value = TaskInfo(task_id="bla", uid=2)
@@ -96,4 +96,76 @@ class TestLatestRun:
                 exclude_fields={"llm_completions"},
                 limit=1,
             ),
+        )
+
+    async def test_latest_run_includes_metadata(
+        self,
+        test_api_client: AsyncClient,
+        returned_run: AgentRun,
+    ):
+        """Test that metadata is included in the RunV1 response"""
+        returned_run.metadata = {"environment": "test", "user_id": "123", "custom_field": "value"}
+
+        response = await test_api_client.get("/v1/_/agents/bla/runs/latest")
+        assert response.status_code == 200
+
+        response_data = response.json()
+        assert response_data["id"] == returned_run.id
+        assert response_data["metadata"] == {
+            "environment": "test",
+            "user_id": "123",
+            "custom_field": "value",
+        }
+
+    async def test_latest_run_with_null_metadata(
+        self,
+        test_api_client: AsyncClient,
+        returned_run: AgentRun,
+    ):
+        """Test that null metadata is handled correctly"""
+        returned_run.metadata = None
+
+        response = await test_api_client.get("/v1/_/agents/bla/runs/latest")
+        assert response.status_code == 200
+
+        response_data = response.json()
+        assert response_data["id"] == returned_run.id
+        # metadata should not be present in response when it's None (due to response_model_exclude_none=True)
+        assert "metadata" not in response_data
+
+
+class TestGetRunByID:
+    # test_api_client is in the arg to be sure the mock happens after the test_api_client is created
+    @pytest.fixture()
+    def returned_run(test_api_client: Any, mock_storage: Mock):
+        run = task_run_ser(id=str(uuid7()), task_uid=1, task_schema_id=1, status="success")
+        mock_storage.task_runs.fetch_task_run_resource.return_value = run
+        mock_storage.tasks.get_task_info.return_value = TaskInfo(task_id="bla", uid=2)
+        return run
+
+    async def test_get_run_includes_metadata(
+        self,
+        test_api_client: AsyncClient,
+        returned_run: AgentRun,
+        mock_storage: Mock,
+    ):
+        """Test that metadata is included in the get_run response"""
+        returned_run.metadata = {"environment": "production", "user_id": "456", "custom_data": "test_value"}
+
+        response = await test_api_client.get(f"/v1/_/agents/test_task/runs/{returned_run.id}")
+        assert response.status_code == 200
+
+        response_data = response.json()
+        assert response_data["id"] == returned_run.id
+        assert response_data["metadata"] == {
+            "environment": "production",
+            "user_id": "456",
+            "custom_data": "test_value",
+        }
+
+        mock_storage.task_runs.fetch_task_run_resource.assert_called_once_with(
+            ("bla", 2),
+            returned_run.id,
+            exclude={"llm_completions"},
+            include=None,
         )


### PR DESCRIPTION
The `RunV1` API model was updated to include a `metadata` field.

*   A `metadata: dict[str, Any] | None` field was added to the `_BaseRunV1` class in `api/api/routers/runs_v1.py`, which is inherited by `RunV1` and `RunItemV1`.
*   The `from_domain` and `from_domain_task_run` conversion methods in `api/api/routers/runs_v1.py` were modified to populate this `metadata` field from the underlying `AgentRun` domain model, which already contained this information.
*   This change ensures that user-defined key-value pairs stored with an `AgentRun` are now exposed via the `/v1/runs` API endpoints.
*   Comprehensive tests were added to `api/api/routers/runs_v1_test.py`, including `test_latest_run_includes_metadata` and `test_latest_run_with_null_metadata`, to verify correct metadata inclusion and handling of `None` values (which are excluded from the response due to `response_model_exclude_none=True`).