### PR TITLE
Rename chat interface from 'agent' to 'AI Engineer'

### DIFF
--- a/api/api/services/internal_tasks/meta_agent_service.py
+++ b/api/api/services/internal_tasks/meta_agent_service.py
@@ -94,7 +94,7 @@ from core.utils.hash import compute_obj_hash
 from core.utils.tool_utils.tool_utils import get_tools_description_openai_format_str
 from core.utils.url_utils import extract_and_fetch_urls
 
-FIRST_MESSAGE_CONTENT = "Hi, I'm WorkflowAI's agent. How can I help you?"
+FIRST_MESSAGE_CONTENT = "Hi, I'm WorkflowAI's AI Engineer. How can I help you?"
 
 
 def _reverse_optional_bool(value: bool | None) -> bool | None:

--- a/api/api/services/internal_tasks/meta_agent_service_test.py
+++ b/api/api/services/internal_tasks/meta_agent_service_test.py
@@ -318,7 +318,7 @@ class TestMetaAgentService:
                         MetaAgentChatMessage(
                             sent_at=datetime.datetime(2025, 4, 17, 12, 56, 41, 413541, tzinfo=datetime.timezone.utc),
                             role="ASSISTANT",
-                            content="Hi, I'm WorkflowAI's agent. How can I help you?",
+                            content="Hi, I'm WorkflowAI's AI Engineer. How can I help you?",
                             kind="non_specific",
                         ),
                     ],

--- a/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/Chat/PlaygroundChat.tsx
+++ b/client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/Chat/PlaygroundChat.tsx
@@ -329,7 +329,7 @@ export function PlaygroundChat(props: Props) {
         />
         <div className='flex flex-col w-full h-full bg-white'>
           <div className='flex flex-row text-[13px] text-gray-500 font-medium px-4 py-2 items-center justify-between border-b border-gray-100'>
-            <div>Agent</div>
+            <div>AI Engineer</div>
             <div className='flex flex-row items-center gap-4'>
               <SimpleTooltip content='Start New Chat' tooltipDelay={0} side='bottom' tooltipClassName='m-1'>
                 <Button


### PR DESCRIPTION
# Rename Chat Interface from 'Agent' to 'AI Engineer'

## 🎯 Overview
This PR updates the chat interface branding to refer to the assistant as "AI Engineer" instead of the generic term "agent", providing a more professional and specific identity for users.

## 📝 Changes Made

### Backend Changes
- **`api/api/services/internal_tasks/meta_agent_service.py`**
  - Updated `FIRST_MESSAGE_CONTENT` constant from "Hi, I'm WorkflowAI's agent" to "Hi, I'm WorkflowAI's AI Engineer"

### Frontend Changes  
- **`client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/Chat/PlaygroundChat.tsx`**
  - Changed chat header from "Agent" to "AI Engineer"

### Test Updates
- **`api/api/services/internal_tasks/meta_agent_service_test.py`**
  - Updated test expectations to match the new greeting message

## 🧪 Testing
- ✅ All backend linter checks pass (`ruff check`)
- ✅ All frontend TypeScript checks pass
- ✅ Meta agent service tests pass (3/3 test cases)
- ✅ No breaking changes introduced

## 🔍 Visual Impact
**Before**: 
- Chat header: "Agent"  
- Greeting: "Hi, I'm WorkflowAI's agent. How can I help you?"

**After**:
- Chat header: "AI Engineer"
- Greeting: "Hi, I'm WorkflowAI's AI Engineer. How can I help you?"

## 💭 Rationale
The term "AI Engineer" better reflects the specialized nature of the assistant and provides users with a clearer understanding of the chat interface's purpose as an engineering-focused AI companion.

## 📦 Files Changed
- `api/api/services/internal_tasks/meta_agent_service.py` (1 line)
- `client/src/app/[tenant]/agents/[taskId]/[taskSchemaId]/playground/components/Chat/PlaygroundChat.tsx` (1 line) 
- `api/api/services/internal_tasks/meta_agent_service_test.py` (1 line)

**Total**: 3 files changed, 3 insertions(+), 3 deletions(-)