### PR TITLE
Add .playground/ to .gitignore for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,5 @@ junit
 openapi_fixed.json
 .ignored
 .source
+
+.playground/


### PR DESCRIPTION
## Description
This change adds `.playground/` to the .gitignore file to provide developers with a dedicated folder for local development scripts and testing.

## Benefits
- 🧪 **Testing**: Particularly useful for MCP server testing and development
- 📝 **Scripts**: Allows developers to store local development scripts without accidentally committing them  
- 🔒 **Safety**: Prevents local development files from being committed to the repository
- 🚀 **Productivity**: Enables quick prototyping and testing without worrying about git status

## Changes
- Added `.playground/` entry to .gitignore

This is a simple but valuable improvement for the developer experience, providing a safe space for local experimentation and testing.

**Note**: This is a clean PR that only includes the .gitignore change.