### PR TITLE
Update taskRunId to runId in URLs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "None",
+  "python.languageServer": "Pylance",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["-vv", "-s"],
-  "python.languageServer": "Pylance",
+  "python.languageServer": "None",
   "python.analysis.autoImportCompletions": true,
   "editor.suggestSelection": "first",
   "editor.quickSuggestions": {

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -36,6 +36,6 @@ export const HARDCODED_TENANT =
 
 export const STRIPE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
-export const TASK_RUN_ID_PARAM = 'taskRunId';
+export const TASK_RUN_ID_PARAM = 'runId';
 
 export const UNKNOWN_USER_ID_COOKIE_NAME = 'x-unknown-user-id';

--- a/client/src/lib/routeFormatter.ts
+++ b/client/src/lib/routeFormatter.ts
@@ -116,7 +116,7 @@ export const taskSampleRoute = (tenant: TenantID, taskId: TaskID, taskSchemaId: 
   `${taskSchemaRoute(tenant, taskId, taskSchemaId)}/examples/${taskSampleId}`;
 
 export function taskRunRoute(tenant: TenantID, taskId: TaskID, taskSchemaId: TaskSchemaID, taskRunId: string) {
-  return `/${decodeURIComponent(tenant)}/agents/${taskId}/${taskSchemaId}/runs?taskRunId=${taskRunId}`;
+  return `/${decodeURIComponent(tenant)}/agents/${taskId}/${taskSchemaId}/runs?runId=${taskRunId}`;
 }
 
 export function replaceTenant(url: string, urlTenant: string, tenant: string) {


### PR DESCRIPTION
The URL parameter `taskRunId` was renamed to `runId` to align with the deprecation of the 'task' concept in public-facing URLs.

Changes were applied to two key files:
*   In `client/src/lib/constants.ts`, the `TASK_RUN_ID_PARAM` constant was updated from `'taskRunId'` to `'runId'`.
*   In `client/src/lib/routeFormatter.ts`, the `taskRunRoute` function was modified to construct URLs using `?runId=` instead of `?taskRunId=`.

This ensures that URLs previously formatted as `.../runs?page=0&taskRunId=...` now appear as `.../runs?page=0&runId=...`, reflecting the updated parameter name in public routes as intended. Internal references to `taskRunId` not affecting public URLs were left unchanged.