### PR TITLE
docs: clarify supported endpoints in getting started guides

### DIFF
--- a/docsv2/content/docs/use-cases/migrating_existing_agent.mdx
+++ b/docsv2/content/docs/use-cases/migrating_existing_agent.mdx
@@ -2,7 +2,22 @@
 title: Migrating an existing agent with WorkflowAI
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
+
 ## Overview
+
+<Callout type="warning">
+**Important: Endpoint Compatibility**
+
+WorkflowAI only supports the OpenAI `/v1/chat/completions` endpoint. If your existing agent uses other OpenAI endpoints, you'll need to maintain separate clients:
+
+- **Supported**: `/v1/chat/completions` - Migrate this to WorkflowAI
+- **Not Supported**: `/v1/embeddings`, `/v1/responses`, `/v1/audio/*`, `/v1/images/*`, and other OpenAI endpoints
+
+**Migration Strategy**: Only change the client configuration for your chat/completions requests. Keep using the standard OpenAI client for all other endpoints (embeddings, responses API, audio transcriptions, image generation, etc.).
+</Callout>
+
+When migrating an existing agent to WorkflowAI, you'll get immediate access to 100+ models, observability features, and improved reliability while maintaining full compatibility with your existing chat completion code.
 
 ## Step 1: Understand the agent
 

--- a/docsv2/content/docs/use-cases/new_agent.mdx
+++ b/docsv2/content/docs/use-cases/new_agent.mdx
@@ -2,6 +2,8 @@
 title: Building a new agent with WorkflowAI
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
+
 **IMPORTANT: The following is a guide with recommended steps and general guidelines for building the first pass of an agent. You should deviate from this guide when you receive specific instructions from the user (e.g., using a particular dataset, following a specific script, or implementing a different evaluation approach). Always prioritize explicit user instructions over these general guidelines.**
 
 ## Framework Overview
@@ -71,6 +73,10 @@ There are two main types of AI agents, each requiring different approaches:
 Note that **prompts and models are interconnected** - you may need to adjust prompts for specific models or try different model-prompt combinations. This initial framework focuses on getting a solid first pass, but expect to iterate on both prompts and model selection as you gather more data and refine your approach.
 
 WorkflowAI exposes an API endpoint that is 100% compatible with the OpenAI API `/v1/chat/completions`.
+
+<Callout type="warning">
+**Supported Endpoints**: WorkflowAI only supports the `/v1/chat/completions` endpoint. Other OpenAI endpoints like embeddings (`/v1/embeddings`), responses API (`/v1/responses`), audio transcriptions, and image generation are not supported. If you need these features, continue using the standard OpenAI client for those specific endpoints.
+</Callout>
 
 So, in order to build a new agent, you can use the OpenAI SDK, for example:
 


### PR DESCRIPTION
## Summary

Adds prominent callouts to clarify that WorkflowAI only supports the  endpoint, addressing potential confusion for users who may expect full OpenAI API compatibility.

## Changes

### 📝 Documentation Updates

- **new_agent.mdx**: Added warning callout after API compatibility statement
- **migrating_existing_agent.mdx**: Added comprehensive endpoint compatibility section in Overview

### 🎯 Key Improvements

**Clearly Communicates Limitations:**
- Only  endpoint is supported
- Lists specific unsupported endpoints: embeddings, responses API, audio, images
- Provides clear migration strategy for mixed-endpoint scenarios

**Strategic Positioning:**
- New agent guide: Callout placed right after API compatibility mention
- Migration guide: Prominent callout at top of Overview section for maximum visibility

**Actionable Guidance:**
- Tells users exactly what to migrate vs. what to keep with standard OpenAI client
- Reduces confusion about endpoint support

## Context

Based on research of the docsv2 folder, endpoint limitations were only mentioned in a buried troubleshooting accordion. This change makes the limitations prominent and clear for users getting started with WorkflowAI.

## Files Changed

- 
- 