### PR TITLE
Rename MCP tool from list_available_models to list_models

### DIFF
--- a/.discussions/elegant_sorting_implementation.md
+++ b/.discussions/elegant_sorting_implementation.md
@@ -58,7 +58,7 @@ def sort_models(models: list[ConciseModelResponse | ConciseLatestModelResponse],
 
 ### MCP Tool Parameters
 
-**list_available_models tool:**
+**list_models tool:**
 
 ```json
 {

--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -138,7 +138,7 @@ class MCPService:
             ],
         )
 
-    async def list_available_models(
+    async def list_models(
         self,
         page: int,
         sort_by: ModelSortField,

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -140,7 +140,7 @@ async def get_task_tuple_from_task_id(storage: BackendStorage, agent_id: str) ->
 
 
 @_mcp.tool()
-async def list_available_models(
+async def list_models(
     agent_id: Annotated[
         str | None,
         Field(
@@ -183,7 +183,7 @@ async def list_available_models(
     Returns a list of all available AI models from WorkflowAI.
     </returns>"""
     service = await get_mcp_service()
-    return await service.list_available_models(
+    return await service.list_models(
         page=page,
         agent_id=agent_id,
         agent_schema_id=agent_schema_id,

--- a/api/api/routers/mcp/mcp_server_DOCS.md
+++ b/api/api/routers/mcp/mcp_server_DOCS.md
@@ -93,7 +93,7 @@ For production:
 The MCP server exposes 5 tools for working with WorkflowAI agents:
 
 1. **`ask_ai_engineer`** - Get help from WorkflowAI's AI engineer
-2. **`list_available_models`** - List all available AI models
+2. **`list_models`** - List all available AI models
 3. **`fetch_run_details`** - Get detailed information about a specific agent run
 4. **`list_agents_with_stats`** - List all agents with performance statistics
 5. **`get_agent_versions`** - Retrieve version information for a specific agent

--- a/api/tests/integration/mcp/cases/2_create_new_agent/evaluator.yaml
+++ b/api/tests/integration/mcp/cases/2_create_new_agent/evaluator.yaml
@@ -1,5 +1,5 @@
 required_tools:
-  - name: list_available_models
+  - name: list_models
 assertions:
   code:
     - a route was added with an agent using the openai sdk

--- a/api/tests/integration/mcp/fixtures/claude_steps.json
+++ b/api/tests/integration/mcp/fixtures/claude_steps.json
@@ -21,7 +21,7 @@
       "TodoRead",
       "TodoWrite",
       "WebSearch",
-      "mcp__workflowai__list_available_models",
+      "mcp__workflowai__list_models",
       "mcp__workflowai__list_agents",
       "mcp__workflowai__fetch_run_details",
       "mcp__workflowai__get_agent_versions",
@@ -172,7 +172,7 @@
         {
           "type": "tool_use",
           "id": "toolu_0138UxnJFUKfqXQqjdGiKd2N",
-          "name": "mcp__workflowai__list_available_models",
+          "name": "mcp__workflowai__list_models",
           "input": {}
         }
       ],

--- a/api/tests/integration/mcp/mcp_test.py
+++ b/api/tests/integration/mcp/mcp_test.py
@@ -52,7 +52,7 @@ def _list_cases():
 # For now, it looks like passing a wildcard `mcp__{_MCP_NAME}__` in allowed tools
 # does not work so we need to manually list the tools...
 _WAI_TOOLS = [
-    "list_available_models",
+    "list_models",
     "list_agents",
     "fetch_run_details",
     "get_agent_versions",

--- a/docsv2/content/docs/inference/models.mdx
+++ b/docsv2/content/docs/inference/models.mdx
@@ -154,8 +154,8 @@ You can access the [list of models](https://run.workflowai.com/v1/models) and th
 
 ### Using MCP
 
-```
-(show text that will trigger the list_models tool)
+```bash
+list_models
 ```
 
 ### List

--- a/docsv2/content/docs/reference/supported-models.mdx
+++ b/docsv2/content/docs/reference/supported-models.mdx
@@ -8,4 +8,16 @@ import { WorkflowModelsWrapper } from '@/components/workflow-models-wrapper';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { WorkflowModelCount } from '@/components/workflow-model-count';
 
+## Access via MCP
+
+```bash
+list_models
+```
+
+## Access via API
+
+```bash
+curl -X GET "https://run.workflowai.com/v1/models"
+```
+
 <WorkflowModelsWrapper />

--- a/docsv2/content/docs/use-cases/improving_and_debugging_existing_agent.mdx
+++ b/docsv2/content/docs/use-cases/improving_and_debugging_existing_agent.mdx
@@ -32,7 +32,7 @@ If increasing `max_tokens` doesn't solve the issue, you may be hitting the model
 
 **Use MCP tools to find models with larger context windows:**
 
-- Use `list_available_models` with `sort_by="max_tokens"` and `order="desc"` to see models with the highest context windows first
+- Use `list_models` with `sort_by="max_tokens"` and `order="desc"` to see models with the highest context windows first
 - Alternatively, use the v1/models API endpoint to get current context window information
 - Compare your current model's limits with available alternatives
 


### PR DESCRIPTION
This PR renames the MCP tool function from  to  to be more concise and consistent with other tooling conventions.

## Changes Made

- ✅ Renamed function from  to  in MCP server
- ✅ Updated service implementation to use new function name
- ✅ Updated all test files and fixtures to use new function name
- ✅ Updated documentation to reflect the new function name

## Testing

- Type checking passes with no errors
- All references have been updated consistently across the codebase

## Context

The current function name  was verbose and the shorter  is more consistent with standard naming conventions. The documentation already expected this naming.

Closes: [WOR-5055](https://linear.app/workflowai/issue/WOR-5055/rename-mcp-tool-from-list-available-models-to-list-models)