### PR TITLE
docs: remove /docs prefix from internal links in docsv2

### DIFF
--- a/docsv2/content/docs/compliance.mdx
+++ b/docsv2/content/docs/compliance.mdx
@@ -60,7 +60,7 @@ For organizations with particularly strict compliance, data residency, or securi
 <Card
   title="Self-Hosting Guide"
   description="Learn how to deploy WorkflowAI in your own environment for maximum control and compliance."
-  href="/docs/self-hosting"
+  href="/self-hosting"
 />
 
 <Callout type="info">

--- a/docsv2/content/docs/deployments/index.mdx
+++ b/docsv2/content/docs/deployments/index.mdx
@@ -44,7 +44,7 @@ This example shows an agent that extracts event details from emails using input 
 Here's our initial agent with a hardcoded prompt:
 
 <Callout type="info">
-This agent is using Structured Outputs. Learn more about [Structured Outputs](/docs/inference/structured-outputs).
+This agent is using Structured Outputs. Learn more about [Structured Outputs](/inference/structured-outputs).
 </Callout>
 
 ```python
@@ -206,7 +206,7 @@ For both scenarios, the deployment process is the same:
 
 The deployment will be associated with a schema number that defines:
 - **Input variables** your code must provide (if any)
-- **Output format** (`response_format`) your code expects (when using [Structured Outputs](/docs/inference/structured-outputs))
+- **Output format** (`response_format`) your code expects (when using [Structured Outputs](/inference/structured-outputs))
 
 You can view all schemas in the **Schemas** section of the WorkflowAI dashboard.
 
@@ -271,7 +271,7 @@ When there's a mismatch between your code and the deployed schema (missing input
 
 ## Important notes
 
-- **Agent-specific**: Deployments work with named agents only, not the `default` agent. Learn how to [identify your agent](/docs/inference/models#identifying-your-agent).
+- **Agent-specific**: Deployments work with named agents only, not the `default` agent. Learn how to [identify your agent](/inference/models#identifying-your-agent).
 - **Environment isolation**: Each environment (development/staging/production) has independent deployments.
 - **Schema independence**: You can have different deployments for each schema without affecting each other.
 - **Input variables optional**: Not all agents need input variables: simple chatbots can store all instructions in the deployed prompt.

--- a/docsv2/content/docs/deployments/index.mdx
+++ b/docsv2/content/docs/deployments/index.mdx
@@ -35,7 +35,7 @@ Teams typically use deployments when they want:
 
 Let's walk through two common scenarios for setting up deployments.
 
-### Scenario 1: Data Extraction Agent (with input variables)
+### Scenario 1: Data extraction agent (with input variables)
 
 This example shows an agent that extracts event details from emails using input variables.
 
@@ -94,7 +94,13 @@ completion = client.beta.chat.completions.parse(
 )
 ```
 
-**Why input variables?** Input variables help WorkflowAI understand which parts of your prompt are dynamic (change with each request) versus static (part of the prompt template). This separation allows prompt engineers to modify the static template without affecting the dynamic data your code provides.
+<Callout type="info">
+**Why input variables?**
+
+Input variables help WorkflowAI understand which parts of your prompt are dynamic (change with each request) versus static (part of the prompt template). This separation allows anyone to modify the static template without affecting the dynamic data your code provides.
+
+Learn more about input variables, including template syntax and examples, in the [Input Variables documentation](/observability/input-variables).
+</Callout>
 
 #### Step 3: Deploy the version and update code
 
@@ -117,7 +123,7 @@ completion = client.beta.chat.completions.parse(
 )
 ```
 
-### Scenario 2: Chatbot Agent (no input variables needed)
+### Scenario 2: Chatbot agent (no input variables needed)
 
 This example shows a chatbot where all instructions are stored as the system message in WorkflowAI.
 

--- a/docsv2/content/docs/evaluations/user-feedback.mdx
+++ b/docsv2/content/docs/evaluations/user-feedback.mdx
@@ -148,7 +148,7 @@ Backend                              Frontend                             Workfl
 
  Chat Completions API
 
-  The feedback token is also returned in the chat completions response. See the [API Responses documentation](/docs/reference/api-responses.md) for more details.
+  The feedback token is also returned in the chat completions response. See the [API Responses documentation](/reference/api-responses.md) for more details.
 
   ```
   POST /v1/chat/completions

--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -17,15 +17,15 @@ WorkflowAI is the [open-source](https://github.com/workflowai/workflowai) platfo
 
 <Card
   title="Get started building your agent without writing any code."
-  href="/docs/quickstarts/no-code"
+  href="/quickstarts/no-code"
 />
 
 ### Option 2: Migrate your existing agents
 
-With just a few minutes and two simple code changes, you can migrate your existing agents to WorkflowAI to [access 100+ models](/docs/inference/models), use the [playground](/docs/playground) for comparing models side-by-side, [observe](/docs/observability) your agents' behavior in real-time, and run on a [scalable and reliable inference infrastructure](/docs/inference/reliability).
+With just a few minutes and two simple code changes, you can migrate your existing agents to WorkflowAI to [access 100+ models](/inference/models), use the [playground](/playground) for comparing models side-by-side, [observe](/observability) your agents' behavior in real-time, and run on a [scalable and reliable inference infrastructure](/inference/reliability).
 
-<Callout type="info" href="/docs/pricing">
-By switching to WorkflowAI, you won't pay more than your current inference costs. We price match the providers and make our margin through volume discounts. [Learn more about our pricing](/docs/pricing).
+<Callout type="info" href="/pricing">
+By switching to WorkflowAI, you won't pay more than your current inference costs. We price match the providers and make our margin through volume discounts. [Learn more about our pricing](/pricing).
 </Callout>
 
 <Tabs items={['OpenAI Python', 'OpenAI Javascript/TS', 'Instructor Python']} groupId="integration-examples" persist updateAnchor>
@@ -33,7 +33,7 @@ By switching to WorkflowAI, you won't pay more than your current inference costs
     <include>partials/openai-python-code.mdx</include>
     
     <Callout type="info">
-      **Get Started**: [OpenAI Python SDK Integration Guide →](/docs/quickstarts/openai-python)
+      **Get Started**: [OpenAI Python SDK Integration Guide →](/quickstarts/openai-python)
     </Callout>
   </Tab>
   
@@ -41,7 +41,7 @@ By switching to WorkflowAI, you won't pay more than your current inference costs
     <include>partials/openai-javascript-code.mdx</include>
     
     <Callout type="info">
-      **Get Started**: [OpenAI Javascript/TS Integration Guide →](/docs/quickstarts/openai-javascript-typescript)
+      **Get Started**: [OpenAI Javascript/TS Integration Guide →](/quickstarts/openai-javascript-typescript)
     </Callout>
   </Tab>
   
@@ -49,7 +49,7 @@ By switching to WorkflowAI, you won't pay more than your current inference costs
     <include>partials/instructor-python-code.mdx</include>
     
     <Callout type="info">
-      **Get Started**: [Instructor Python Integration Guide →](/docs/quickstarts/instructor-python)
+      **Get Started**: [Instructor Python Integration Guide →](/quickstarts/instructor-python)
     </Callout>
   </Tab>
 </Tabs>
@@ -63,7 +63,7 @@ By switching to WorkflowAI, you won't pay more than your current inference costs
 <Card
   title="Playground"
   description="Our goal is to build the best playground that supports all leading AI models."
-  href="/docs/playground"
+  href="/playground"
 />
 
 ### Inference
@@ -91,7 +91,7 @@ should we show all the sections from inference, or just the header?
 ![header](</images/overview/evaluations.png>)
 
 <Callout type="info">
-**Enterprise Compliance**: SOC2 & GDPR compliant. No training on your data. [Learn more](/docs/compliance).
+**Enterprise Compliance**: SOC2 & GDPR compliant. No training on your data. [Learn more](/compliance).
 </Callout>
 
 ## Join the community

--- a/docsv2/content/docs/inference/cost.mdx
+++ b/docsv2/content/docs/inference/cost.mdx
@@ -57,5 +57,5 @@ TODO:
 #### ...
 
 <Callout type="info">
-  You can also track costs in the [Playground](/docs/playground) and the [Monitor](/docs/observability) sections.
+  You can also track costs in the [Playground](/playground) and the [Monitor](/observability) sections.
 </Callout>

--- a/docsv2/content/docs/inference/models.mdx
+++ b/docsv2/content/docs/inference/models.mdx
@@ -15,7 +15,7 @@ import { WorkflowModelCount } from '@/components/workflow-model-count';
 To use a specific model, simply change the `model` parameter in your API call.
 
 <Callout type="info">
-  To properly organize your observability data, you can identify your agent by adding `agent_id` to your metadata (preferred method) or by using an agent prefix in the model parameter when metadata editing isn't possible. This helps you track and debug runs for specific agents. Learn more about [identifying your agent](/docs/observability#identify-your-agent).
+  To properly organize your observability data, you can identify your agent by adding `agent_id` to your metadata (preferred method) or by using an agent prefix in the model parameter when metadata editing isn't possible. This helps you track and debug runs for specific agents. Learn more about [identifying your agent](/observability#identify-your-agent).
 </Callout>
 
 <Tabs items={["Python", "JavaScript", "curl"]}>

--- a/docsv2/content/docs/observability/conversations.mdx
+++ b/docsv2/content/docs/observability/conversations.mdx
@@ -45,7 +45,7 @@ A conversation can represent either:
 - A series of LLM completions involving tool calls
 
 <Callout type="warning">
-A conversation is always agent specific, meaning that runs that have the same conversation id but are from different agents are not considered part of the same conversation. Make sure to set [`agent_id`](/docs/observability#identify-your-agent) in the `metadata` of your requests.
+A conversation is always agent specific, meaning that runs that have the same conversation id but are from different agents are not considered part of the same conversation. Make sure to set [`agent_id`](/observability#identify-your-agent) in the `metadata` of your requests.
 </Callout>
 
 <Callout type="info">
@@ -233,7 +233,7 @@ curl -X POST https://run.workflowai.com/v1/chat/completions \
 To access a specific conversation, you need the `conversation_id`. There are two ways to obtain the `conversation_id`:
 
 - **Manual conversation grouping**: If you [manually set a `conversation_id`](#manual-conversation-grouping), the `conversation_id` is available immediately in your code
-- **Automatic conversation grouping**: The `conversation_id` is generated during run storage and is not returned in the inference response. You can retrieve the `conversation_id` later using the [runs API endpoints](/docs/observability/runs) (e.g., `/runs/{id}` or `/runs/search`), or in the UI.
+- **Automatic conversation grouping**: The `conversation_id` is generated during run storage and is not returned in the inference response. You can retrieve the `conversation_id` later using the [runs API endpoints](/observability/runs) (e.g., `/runs/{id}` or `/runs/search`), or in the UI.
 
 Once you have the `conversation_id`, you can view the conversation:
 

--- a/docsv2/content/docs/observability/costs.mdx
+++ b/docsv2/content/docs/observability/costs.mdx
@@ -24,4 +24,4 @@ On WorkflowAI, you can track costs in the Cost page from the Monitor section:
 ### Programmatically
 
 You can also track costs programmatically in the response from the API when running an agent.
-View the [Cost Metadata](/docs/inference/cost) page for more details.
+View the [Cost Metadata](/inference/cost) page for more details.

--- a/docsv2/content/docs/observability/index.mdx
+++ b/docsv2/content/docs/observability/index.mdx
@@ -21,7 +21,7 @@ explain why...
 
 ### Go through the Quickstart
 
-Because inference requests are going through WorkflowAI, observability is enabled automatically as soon you have completed the [Quickstart](/docs/quickstarts).
+Because inference requests are going through WorkflowAI, observability is enabled automatically as soon you have completed the [Quickstart](/quickstarts).
 
 </Step>
 

--- a/docsv2/content/docs/observability/input-variables.mdx
+++ b/docsv2/content/docs/observability/input-variables.mdx
@@ -181,12 +181,12 @@ extra_body = {
 
 When you use input variables, WorkflowAI automatically separates them in the run view:
 
-- **Task Input**: Shows the variables you provided
-- **Task Output**: Shows the agent's response
+- **Agent Input**: Shows the variables you provided
+- **Agent Output**: Shows the agent's response
 - **Prompt View**: Shows the final rendered prompt with variables substituted
 
 <Callout type="todo">
-**TODO for Anya**: Add screenshot showing the run details view with input variables separated from output, highlighting the Task Input, Task Output, and Prompt View sections.
+**TODO for Anya**: Add screenshot showing the run details view with input variables separated from output, highlighting the Agent Input, Agent Output, and Prompt View sections.
 </Callout>
 
 <Callout type="info">

--- a/docsv2/content/docs/observability/input-variables.mdx
+++ b/docsv2/content/docs/observability/input-variables.mdx
@@ -1,0 +1,272 @@
+---
+title: Input Variables
+description: Separate your agent instructions from dynamic data to improve debugging, enable deployments, and make your agents more maintainable and testable.
+summary: Documentation on using input variables with agents for better observability and debugging. Covers Jinja2 template syntax, common errors, and best practices.
+---
+
+import { Tabs, Tab } from "fumadocs-ui/components/tabs"
+import { Callout } from "fumadocs-ui/components/callout"
+
+## Overview
+
+Input variables allow you to separate static agent instructions from dynamic data, making your agents more maintainable and observable. They use **Jinja2 template syntax** with double braces `{{variable_name}}` to inject variables into your prompts at runtime.
+
+<Callout type="info">
+**Benefits of Input Variables:**
+- **Better Observability**: Clear separation between static instructions and dynamic data.
+- **Easier Debugging**: Variables are displayed separately in run details.
+- **Deployment Support**: Required for [deployments](/deployments) to be able to edit prompts without a code change.
+</Callout>
+
+## Basic Usage
+
+### Providing Input Variables
+
+Input variables are provided via the `extra_body` parameter in your completion request:
+
+<Tabs items={['Python', 'TypeScript', 'cURL']}>
+<Tab value="Python">
+```python
+completion = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{
+        "role": "user", 
+        "content": "Analyze this email: {{email_content}}"
+    }],
+    extra_body={
+        "input": {
+            "email_content": "Dear team, please review the quarterly report..."
+        }
+    },
+    metadata={"agent_id": "email-analyzer"}
+)
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+// @ts-expect-error input is specific to the WorkflowAI implementation
+const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{
+        role: "user",
+        content: "Analyze this email: {{email_content}}"
+    }],
+    input: {
+        email_content: "Dear team, please review the quarterly report..."
+    },
+    metadata: { agentId: "email-analyzer" }
+});
+```
+</Tab>
+<Tab value="cURL">
+```sh
+curl -X POST https://run.workflowai.com/v1/chat/completions \
+-H "Authorization: Bearer $WORKFLOWAI_API_KEY" \
+-H "Content-Type: application/json" \
+-d '{
+    "model": "gpt-4o-mini",
+    "messages": [{
+        "role": "user",
+        "content": "Analyze this email: {{email_content}}"
+    }],
+    "extra_body": {
+        "input": {
+            "email_content": "Dear team, please review the quarterly report..."
+        }
+    },
+    "metadata": {"agent_id": "email-analyzer"}
+}'
+```
+</Tab>
+</Tabs>
+
+### Template Syntax
+
+WorkflowAI uses **Jinja2** templating with these key patterns:
+
+| Pattern | Usage | Example |
+|---------|-------|---------|
+| `{{variable}}` | Simple variable substitution | `{{user_name}}` |
+| `{{object.property}}` | Nested object access | `{{user.email}}` |
+| `{{list[0]}}` | Array element access | `{{messages[0]}}` |
+| `{% if condition %}` | Conditional logic | `{% if is_premium %}...{% endif %}` |
+| `{% for item in list %}` | Loop over arrays | `{% for msg in messages %}...{% endfor %}` |
+
+## Examples
+
+<Tabs items={['Single Variable', 'Multiple Variables', 'Complex Nested']}>
+<Tab value="Single Variable">
+```python
+messages = [{
+    "role": "user",
+    "content": "Summarize this text in {{length}} words: {{text}}"
+}]
+
+extra_body = {
+    "input": {
+        "text": "Long article content here...",
+        "length": 50
+    }
+}
+```
+</Tab>
+<Tab value="Multiple Variables">
+```python
+messages = [{
+    "role": "system",
+    "content": "You are a {{role}} helping {{user_name}} with {{task_type}} tasks."
+}, {
+    "role": "user", 
+    "content": "{{user_query}}"
+}]
+
+extra_body = {
+    "input": {
+        "role": "financial advisor",
+        "user_name": "Alice",
+        "task_type": "investment",
+        "user_query": "Should I invest in tech stocks?"
+    }
+}
+```
+</Tab>
+<Tab value="Complex Nested">
+```python
+messages = [{
+    "role": "system",
+    "content": """Process this customer support ticket:
+    
+Customer: {{ticket.customer.name}} ({{ticket.customer.email}})
+Priority: {{ticket.priority}}
+Category: {{ticket.category}}
+
+Previous interactions:
+{% for interaction in ticket.history %}
+- {{interaction.date}}: {{interaction.summary}}
+{% endfor %}
+
+Current issue: {{ticket.description}}"""
+}]
+
+extra_body = {
+    "input": {
+        "ticket": {
+            "customer": {
+                "name": "John Smith",
+                "email": "john@company.com"
+            },
+            "priority": "high",
+            "category": "billing",
+            "description": "Cannot access premium features",
+            "history": [
+                {
+                    "date": "2024-01-15",
+                    "summary": "Initial signup completed"
+                },
+                {
+                    "date": "2024-01-20", 
+                    "summary": "Upgraded to premium plan"
+                }
+            ]
+        }
+    }
+}
+```
+</Tab>
+</Tabs>
+
+## Observability Benefits
+
+### Viewing Variables in Run Details
+
+When you use input variables, WorkflowAI automatically separates them in the run view:
+
+- **Task Input**: Shows the variables you provided
+- **Task Output**: Shows the agent's response
+- **Prompt View**: Shows the final rendered prompt with variables substituted
+
+<Callout type="todo">
+**TODO for Anya**: Add screenshot showing the run details view with input variables separated from output, highlighting the Task Input, Task Output, and Prompt View sections.
+</Callout>
+
+<Callout type="info">
+**Run View**: In the run details, you'll see a clear separation between your input variables and the agent's output, making debugging much easier.
+</Callout>
+
+This separation makes it much easier to:
+- Debug issues with specific input data
+- Understand what changed between runs
+- Test different variable values while keeping instructions constant
+
+### Searching by Variables
+
+You can search for runs using input variable values:
+
+1. Go to the **Runs** section in WorkflowAI
+2. Use the search filters to find runs by:
+   - Specific variable values (e.g., `input.user_id = "12345"`)
+   - Variable existence (e.g., runs that have `input.priority`)
+   - Variable ranges (e.g., `input.score > 0.8`)
+
+<Callout type="todo">
+**TODO for Anya**: Add screenshot of the Runs section showing the search filters interface with examples of searching by input variable values.
+</Callout>
+
+<Callout type="info">
+Learn more about advanced run searching in the [Search documentation](/observability/runs#search-runs).
+</Callout>
+
+## Error Handling and Debugging
+
+### Common Template Errors
+
+<Tabs items={['Missing Variable', 'Syntax Error', 'Nonexistent Properties']}>
+<Tab value="Missing Variable">
+**Error message:**
+```
+Template variable 'user_name' is not defined in input variables
+```
+
+**Solution:** Ensure all variables used in templates are provided in `extra_body.input`:
+
+```python
+# ❌ Missing variable
+messages = [{"role": "user", "content": "Hello {{user_name}}"}]
+extra_body = {"input": {}}  # user_name not provided
+
+# ✅ Correct
+messages = [{"role": "user", "content": "Hello {{user_name}}"}] 
+extra_body = {"input": {"user_name": "Alice"}}
+```
+</Tab>
+<Tab value="Syntax Error">
+**Error message:**
+```
+Template syntax error: unexpected character '{' at line 1
+```
+
+**Common causes:**
+- Single braces instead of double: `{variable}` → `{{variable}}`
+- Unmatched braces: `{{variable}` → `{{variable}}`
+
+</Tab>
+<Tab value="Nonexistent Properties">
+**Error message:**
+```
+Template error: 'dict object' has no attribute 'invalid_property'
+```
+
+**Solution:** Use conditional checks or default values:
+
+```python
+# ❌ May fail if property doesn't exist
+"content": "User email: {{user.email}}"
+
+# ✅ Safe with default
+"content": "User email: {{user.email|default('Not provided')}}"
+
+# ✅ Safe with conditional
+"content": "{% if user.email %}User email: {{user.email}}{% endif %}"
+```
+</Tab>
+</Tabs>

--- a/docsv2/content/docs/observability/input-variables.mdx
+++ b/docsv2/content/docs/observability/input-variables.mdx
@@ -18,9 +18,9 @@ Input variables allow you to separate static agent instructions from dynamic dat
 - **Deployment Support**: Required for [deployments](/deployments) to be able to edit prompts without a code change.
 </Callout>
 
-## Basic Usage
+## Basic usage
 
-### Providing Input Variables
+### Providing input variables
 
 Input variables are provided via the `extra_body` parameter in your completion request:
 
@@ -80,7 +80,7 @@ curl -X POST https://run.workflowai.com/v1/chat/completions \
 </Tab>
 </Tabs>
 
-### Template Syntax
+### Template syntax
 
 WorkflowAI uses **Jinja2** templating with these key patterns:
 
@@ -175,9 +175,9 @@ extra_body = {
 </Tab>
 </Tabs>
 
-## Observability Benefits
+## Observability benefits
 
-### Viewing Variables in Run Details
+### Viewing variables in run details
 
 When you use input variables, WorkflowAI automatically separates them in the run view:
 
@@ -198,7 +198,7 @@ This separation makes it much easier to:
 - Understand what changed between runs
 - Test different variable values while keeping instructions constant
 
-### Searching by Variables
+### Searching by variables
 
 You can search for runs using input variable values:
 
@@ -213,14 +213,14 @@ You can search for runs using input variable values:
 </Callout>
 
 <Callout type="info">
-Learn more about advanced run searching in the [Search documentation](/observability/runs#search-runs).
+Learn more about advanced run searching, including using the MCP tool and API, in the [Search documentation](/observability/runs#search-runs).
 </Callout>
 
-## Error Handling and Debugging
+## Error handling and debugging
 
-### Common Template Errors
+### Common template errors
 
-<Tabs items={['Missing Variable', 'Syntax Error', 'Nonexistent Properties']}>
+<Tabs items={['Missing Variable', 'Syntax Error']}>
 <Tab value="Missing Variable">
 **Error message:**
 ```
@@ -248,25 +248,5 @@ Template syntax error: unexpected character '{' at line 1
 **Common causes:**
 - Single braces instead of double: `{variable}` → `{{variable}}`
 - Unmatched braces: `{{variable}` → `{{variable}}`
-
-</Tab>
-<Tab value="Nonexistent Properties">
-**Error message:**
-```
-Template error: 'dict object' has no attribute 'invalid_property'
-```
-
-**Solution:** Use conditional checks or default values:
-
-```python
-# ❌ May fail if property doesn't exist
-"content": "User email: {{user.email}}"
-
-# ✅ Safe with default
-"content": "User email: {{user.email|default('Not provided')}}"
-
-# ✅ Safe with conditional
-"content": "{% if user.email %}User email: {{user.email}}{% endif %}"
-```
 </Tab>
 </Tabs>

--- a/docsv2/content/docs/observability/insights.mdx
+++ b/docsv2/content/docs/observability/insights.mdx
@@ -53,7 +53,7 @@ This data-driven approach helps you make informed decisions about product improv
 **Coming Soon**: Deep integration between Insights and Reports features to enable natural language analysis of your insights data.
 </Callout>
 
-Once you've collected insights data from your agent interactions, you can use the [Reports](/docs/observability/reports) feature to ask natural language questions about patterns in your insights. This creates a powerful workflow:
+Once you've collected insights data from your agent interactions, you can use the [Reports](/observability/reports) feature to ask natural language questions about patterns in your insights. This creates a powerful workflow:
 
 1. **Collect Insights**: Configure dimensions like sentiment, question_type, is_frustrated, etc.
 2. **Ask Report Questions**: Use natural language to analyze your insights data
@@ -73,7 +73,7 @@ This integration transforms raw insights data into strategic business intelligen
 
 ### Key Concept: 1 Conversation = 1 Insight Analysis
 
-When you have a multi-turn conversation, WorkflowAI automatically groups related runs together (see [Conversations](/docs/observability/conversations)). Insights are then computed **once per conversation** after the conversation ends, not after each individual turn.
+When you have a multi-turn conversation, WorkflowAI automatically groups related runs together (see [Conversations](/observability/conversations)). Insights are then computed **once per conversation** after the conversation ends, not after each individual turn.
 
 **How it works:**
 
@@ -109,7 +109,7 @@ Instead of pre-configuring insights at the agent level, we can embed insights co
 The OpenAI-compatible completion API accepts an optional `insights` field alongside the standard parameters.
 
 <Callout type="info">
-**Important**: Insights can only be attached to runs that include an `agent_id` in the metadata. This is required because insights are computed at the conversation level, and conversations must be grouped by agent. See [Observability Setup](/docs/observability#identify-your-agent) for more details.
+**Important**: Insights can only be attached to runs that include an `agent_id` in the metadata. This is required because insights are computed at the conversation level, and conversations must be grouped by agent. See [Observability Setup](/observability#identify-your-agent) for more details.
 </Callout>
 
 **Naming Convention:**

--- a/docsv2/content/docs/observability/meta.json
+++ b/docsv2/content/docs/observability/meta.json
@@ -1,14 +1,5 @@
 {
   "title": "Observability",
   "icon": "ChartLine",
-  "pages": [
-    "index",
-    "runs",
-    "conversations",
-    "versions",
-    "costs",
-    "insights",
-    "search",
-    "reports"
-  ]
-} 
+  "pages": ["index", "runs", "input-variables", "conversations", "versions", "costs", "insights", "search", "reports"]
+}

--- a/docsv2/content/docs/observability/runs.mdx
+++ b/docsv2/content/docs/observability/runs.mdx
@@ -78,7 +78,7 @@ curl -X POST https://run.workflowai.com/v1/chat/completions \
 | Key | Description | Example | Added automatically |
 |-----|-------------|---------|-------------------|
 | `agent_id` | The ID of the agent that generated the run | `summarizer-agent`, `translation-agent` | No |
-| `conversation_id` | Groups related runs into [conversations](/docs/observability/conversations) for multi-turn interactions | `01234567-89ab-cdef-0123-456789abcdef` | Yes |
+| `conversation_id` | Groups related runs into [conversations](/observability/conversations) for multi-turn interactions | `01234567-89ab-cdef-0123-456789abcdef` | Yes |
 | `environment` | The environment of the run | `production`, `staging`, `development` | Yes, when using a deployment |
 | `source` | The source of the run request | `my+app` (from proxy), `WorkflowAI` (from web app) | Yes |
 | `temperature` | The temperature setting used in the LLM | `0.7`, `1.0` | Yes |
@@ -94,7 +94,7 @@ curl -X POST https://run.workflowai.com/v1/chat/completions \
   TODO: @guillaume is there any limit on the metadata size?
 </Callout>
 
-Then, you can [search for runs by metadata](/docs/observability/runs#search-runs).
+Then, you can [search for runs by metadata](/observability/runs#search-runs).
 
 ## View runs for a specific agent
 

--- a/docsv2/content/docs/observability/search.mdx
+++ b/docsv2/content/docs/observability/search.mdx
@@ -22,7 +22,7 @@ This page will include comprehensive documentation for:
 ## Current Capabilities
 
 For now, you can search for runs using the API endpoints documented in:
-- [Runs documentation](/docs/observability/runs)
-- [Insights search examples](/docs/observability/insights#searching-for-specific-insight-values)
+- [Runs documentation](/observability/runs)
+- [Insights search examples](/observability/insights#searching-for-specific-insight-values)
 
 Stay tuned for expanded search capabilities and a dedicated search interface. 

--- a/docsv2/content/docs/observability/versions.mdx
+++ b/docsv2/content/docs/observability/versions.mdx
@@ -23,8 +23,8 @@ WorkflowAI defines two types of (agent) versions:
 
 Versions are useful for several reasons:
 - They allow you to save a specific configuration of an agent, so you can reproduce it later.
-- They allow you to [compare the performance of different versions of an agent](/docs/playbook/evaluating-your-ai-feature.md).
-- They allow you to [deploy a specific version of an agent](/docs/features/deployments.md).
+- They allow you to [compare the performance of different versions of an agent](/playbook/evaluating-your-ai-feature.md).
+- They allow you to [deploy a specific version of an agent](/features/deployments.md).
 
 
 ## How to:

--- a/docsv2/content/docs/partials/features-cards.mdx
+++ b/docsv2/content/docs/partials/features-cards.mdx
@@ -15,31 +15,31 @@ import { WorkflowModelCount as WorkflowModelCountPartial } from '../../../compon
   <Card 
     title="Compare models side-by-side"
     description="Explore the playground to compare different models and see their outputs in real time."
-    href="/docs/playground"
+    href="/playground"
     icon={<Columns3Icon />}
   />
   <Card 
     title="Observability"
     description="Observe how your agent is performing with detailed logs and analytics."
-    href="/docs/observability"
+    href="/observability"
     icon={<EyeIcon />}
   />
   <Card 
     title="Try new models"
     description={<>Connect to <WorkflowModelCountPartial /> models instantly without any setup or configuration.</>}
-    href="/docs/inference/models"
+    href="/inference/models"
     icon={<PlugZapIcon />}
   />
   <Card 
     title="Tools"
     description="Enable web search and browsing for your agent to access up-to-date information."
-    href="/docs/agents/tools"
+    href="/agents/tools"
     icon={<GlobeIcon />}
   />
   <Card 
     title="100% uptime"
     description="Learn more about how WorkflowAI ensures your agents are always available and reliable."
-    href="/docs/inference/reliability"
+    href="/inference/reliability"
     icon={<ShieldCheckIcon />}
   />
 </Cards> 

--- a/docsv2/content/docs/playground/compare-models.mdx
+++ b/docsv2/content/docs/playground/compare-models.mdx
@@ -6,7 +6,7 @@ summary: Documentation on the side-by-side model comparison feature in the playg
 ## Compare [X] different models to find the best one for your use case. 
 
 ...
-- number of models [view supported models](/docs/reference/supported-models)
+- number of models [view supported models](/reference/supported-models)
 - no setup required (no API key)
 
 The playground is WorkflowAI's tool to allow quick and easy iterating on prompts and models, so you can create the best version of your AI feature possible.

--- a/docsv2/content/docs/pricing.mdx
+++ b/docsv2/content/docs/pricing.mdx
@@ -31,7 +31,7 @@ mistral-7b-instruct | $75 | $75
 | **Paid** | **Free** |
 |----------|----------|
 | Tokens used by your agents | Data storage |
-| [Tools](/docs/agents/tools) used by your agents | Number of agents |
+| [Tools](/agents/tools) used by your agents | Number of agents |
 | | Users in your organization |
 | | Bandwidth or CPU usage |
 
@@ -55,11 +55,11 @@ We monitor provider pricing in real-time and automatically match their per-token
 <Accordion title="Can I use my existing provider credits with WorkflowAI?">
 Yes, you can connect your own API keys from OpenAI, Anthropic, Google, and other providers to use your existing credits while still benefiting from WorkflowAI's tools and infrastructure.
 
-When using your own API keys, WorkflowAI doesn't charge for inference tokens - you pay your provider directly. We only charge for [built-in tools](/docs/agents/tools) that your agents use (like web search, browser, etc.).
+When using your own API keys, WorkflowAI doesn't charge for inference tokens - you pay your provider directly. We only charge for [built-in tools](/agents/tools) that your agents use (like web search, browser, etc.).
 </Accordion>
 
 <Accordion title="How is usage tracked and billed?">
-You're only charged for tokens actually consumed by your agents and any tools they use. We provide detailed [usage analytics](/docs/observability/costs) so you can see exactly what you're paying for. Billing is monthly with no minimums.
+You're only charged for tokens actually consumed by your agents and any tools they use. We provide detailed [usage analytics](/observability/costs) so you can see exactly what you're paying for. Billing is monthly with no minimums.
 </Accordion>
 
 <Accordion title="What happens if my usage is very high or very low?">

--- a/docsv2/content/docs/quickstarts/index.mdx
+++ b/docsv2/content/docs/quickstarts/index.mdx
@@ -11,7 +11,7 @@ Sign up for free and get started with WorkflowAI.
 
 <Card
   title="Create your AI agents without coding."
-  href="/docs/quickstarts/no-code"
+  href="/quickstarts/no-code"
   icon={<Wand2 />}
 />
 
@@ -20,7 +20,7 @@ Sign up for free and get started with WorkflowAI.
 In a few minutes, you can run your existing agents on WorkflowAI's platform.
 
 <Callout type="info">
-WorkflowAI is free to use: you only pay for the underlying AI model usage at the same rates as the providers. [Learn more about pricing](/docs/pricing).
+WorkflowAI is free to use: you only pay for the underlying AI model usage at the same rates as the providers. [Learn more about pricing](/pricing).
 
 Most customers save money because they can quickly identify and switch to cheaper models that meet their performance (quality, latency) requirements.
 </Callout>
@@ -28,7 +28,7 @@ Most customers save money because they can quickly identify and switch to cheape
 <Cards>
   <Card
     title="OpenAI SDK for Python"
-    href="/docs/quickstarts/openai-python"
+    href="/quickstarts/openai-python"
     icon={
       <img 
         src="https://neon.com/images/technology-logos/python.svg" 
@@ -40,7 +40,7 @@ Most customers save money because they can quickly identify and switch to cheape
   />
   <Card
     title="OpenAI SDK for JavaScript/TypeScript"
-    href="/docs/quickstarts/openai-typescript"
+    href="/quickstarts/openai-typescript"
     icon={
       <img 
         src="https://neon.com/images/technology-logos/python.svg" 
@@ -52,7 +52,7 @@ Most customers save money because they can quickly identify and switch to cheape
   />
   <Card
     title="Instructor (Python)"
-    href="/docs/quickstarts/instructor-python"
+    href="/quickstarts/instructor-python"
     icon={
       <img 
         src="https://neon.com/images/technology-logos/python.svg" 

--- a/docsv2/content/docs/quickstarts/instructor-python.mdx
+++ b/docsv2/content/docs/quickstarts/instructor-python.mdx
@@ -65,7 +65,7 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Deployments" 
   description="Update your prompts without changing your code"
-  href="/docs/deployments" 
+  href="/deployments" 
   icon={<UploadCloud />}
 />
 <br />
@@ -73,6 +73,6 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Evaluations" 
   description="Compare prompts and models"
-  href="/docs/evaluations" 
+  href="/evaluations" 
   icon={<BarChart3 />}
 />

--- a/docsv2/content/docs/quickstarts/no-code.mdx
+++ b/docsv2/content/docs/quickstarts/no-code.mdx
@@ -56,7 +56,7 @@ Write a clear description of the feature you want to build and send it to the AI
 
 ### Next: Test and improve your agent
 
-Now that your AI feature is created, head over to the [playground](/docs/playground) to test your agent and make improvements. The playground is where you can refine your agent's behavior, test different scenarios, and ensure it works perfectly for your use case. To help make your agent the best it can be, all the features below are automatically enabled:
+Now that your AI feature is created, head over to the [playground](/playground) to test your agent and make improvements. The playground is where you can refine your agent's behavior, test different scenarios, and ensure it works perfectly for your use case. To help make your agent the best it can be, all the features below are automatically enabled:
 
 <include>../partials/features-cards.mdx</include>
 
@@ -73,7 +73,7 @@ Now that your AI feature is created, head over to the [playground](/docs/playgro
 <Card 
   title="Setup Deployments" 
   description="Update your prompts without changing your code"
-  href="/docs/deployments" 
+  href="/deployments" 
   icon={<UploadCloud />}
 />
 <br />
@@ -81,7 +81,7 @@ Now that your AI feature is created, head over to the [playground](/docs/playgro
 <Card 
   title="Setup Evaluations" 
   description="Compare prompts and models"
-  href="/docs/evaluations" 
+  href="/evaluations" 
   icon={<BarChart3 />}
 
 />

--- a/docsv2/content/docs/quickstarts/openai-agents.mdx
+++ b/docsv2/content/docs/quickstarts/openai-agents.mdx
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 ## Identify your agent
 
 <Callout type="info">
-  **Alternative Method**: This example shows how to identify your agent using the model parameter prefix. This is useful when working with frameworks that don't support custom metadata. The preferred method is to use `agent_id` in the metadata field when possible. Learn more about [both methods](/docs/observability#identify-your-agent).
+  **Alternative Method**: This example shows how to identify your agent using the model parameter prefix. This is useful when working with frameworks that don't support custom metadata. The preferred method is to use `agent_id` in the metadata field when possible. Learn more about [both methods](/observability#identify-your-agent).
 </Callout>
 
 ```python

--- a/docsv2/content/docs/quickstarts/openai-javascript-typescript.mdx
+++ b/docsv2/content/docs/quickstarts/openai-javascript-typescript.mdx
@@ -65,7 +65,7 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Deployments" 
   description="Update your prompts without changing your code"
-  href="/docs/deployments" 
+  href="/deployments" 
   icon={<UploadCloud />}
 />
 <br />
@@ -73,7 +73,7 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Evaluations" 
   description="Compare prompts and models"
-  href="/docs/evaluations" 
+  href="/evaluations" 
   icon={<BarChart3 />}
 />
 <br />
@@ -81,6 +81,6 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Structured Outputs" 
   description="Learn how to get type-safe, validated responses with Pydantic schemas"
-  href="/docs/inference/structured-outputs" 
+  href="/inference/structured-outputs" 
   icon={<ListChecks />}
 />

--- a/docsv2/content/docs/quickstarts/openai-python.mdx
+++ b/docsv2/content/docs/quickstarts/openai-python.mdx
@@ -66,7 +66,7 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Deployments" 
   description="Update your prompts without changing your code"
-  href="/docs/deployments" 
+  href="/deployments" 
   icon={<UploadCloud />}
 />
 <br />
@@ -74,7 +74,7 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Evaluations" 
   description="Compare prompts and models"
-  href="/docs/evaluations" 
+  href="/evaluations" 
   icon={<BarChart3 />}
 />
 <br />
@@ -82,6 +82,6 @@ All the features below are now automatically enabled for your agent.
 <Card 
   title="Setup Structured Outputs" 
   description="Learn how to get type-safe, validated responses with Pydantic schemas"
-  href="/docs/inference/structured-outputs" 
+  href="/inference/structured-outputs" 
   icon={<ListChecks />}
 />

--- a/docsv2/content/docs/reference/api-responses.mdx
+++ b/docsv2/content/docs/reference/api-responses.mdx
@@ -138,7 +138,7 @@ Usage statistics for the completion request.
 ## Extra fields in completion response
 
 In the completion response, the choice object includes the following fields that are not defined in the OpenAI API:
-- **feedback_token**: the feedback token for the completion, as described in the [User Feedback](/docs/guides/user-feedback.md) documentation.
+- **feedback_token**: the feedback token for the completion, as described in the [User Feedback](/guides/user-feedback.md) documentation.
 - **duration_seconds**: the duration of the completion in seconds
 - **cost_usd**: the cost of the generation in USD for that specific choice
 

--- a/docsv2/content/docs/reference/prompt-templating.mdx
+++ b/docsv2/content/docs/reference/prompt-templating.mdx
@@ -10,7 +10,7 @@ WorkflowAI uses **Jinja2** as its templating engine to enable dynamic prompt gen
 
 ## Overview
 
-When using input variables with templates (as shown in the [Using variables in prompts](/docs/guides/using-variables-in-prompts.md) guide), WorkflowAI renders your message templates at runtime using the variables provided in `extra_body["input"]`.
+When using input variables with templates (as shown in the [Using variables in prompts](/guides/using-variables-in-prompts.md) guide), WorkflowAI renders your message templates at runtime using the variables provided in `extra_body["input"]`.
 
 ```python
 instructions = "You must classify the email address as:

--- a/docsv2/content/docs/reference/supported-parameters.mdx
+++ b/docsv2/content/docs/reference/supported-parameters.mdx
@@ -27,7 +27,7 @@ Request body
     stream: {
       description: 'Whether to stream back partial progress',
       type: 'boolean',
-      typeDescriptionLink: '/docs/guides/streaming.md',
+      typeDescriptionLink: '/guides/streaming.md',
     },
     temperature: {
       description: 'What sampling temperature to use, between 0 and 2',

--- a/docsv2/content/docs/use-cases/improving_and_debugging_existing_agent.mdx
+++ b/docsv2/content/docs/use-cases/improving_and_debugging_existing_agent.mdx
@@ -48,7 +48,7 @@ If you're truly hitting context limits:
 
 When debugging production issues, you often know there's an issue affecting a specific user or customer, but don't know which exact runs caused the problem. The solution is to add metadata that matches how you receive bug reports.
 
-**Add metadata fields that correspond to how users report bugs to you.** For detailed information about metadata, see [Metadata in Runs](/docs/observability/runs#metadata).
+**Add metadata fields that correspond to how users report bugs to you.** For detailed information about metadata, see [Metadata in Runs](/observability/runs#metadata).
 
 ### Example: Adding metadata for debugging
 

--- a/docsv2/content/docs/why-workflowai.mdx
+++ b/docsv2/content/docs/why-workflowai.mdx
@@ -10,9 +10,9 @@ WorkflowAI empowers developers to build production-ready AI agents without the c
 
 Built on OpenAI's API standard means your existing code works immediately.
 
-This approach delivers **[zero migration complexity](/docs/quickstarts)** for existing OpenAI-based applications, **easy integration** with your current development workflow, **freedom to move** your code elsewhere if needed, and a **pro-ecosystem approach** that works with your preferred frameworks and tools.
+This approach delivers **[zero migration complexity](/quickstarts)** for existing OpenAI-based applications, **easy integration** with your current development workflow, **freedom to move** your code elsewhere if needed, and a **pro-ecosystem approach** that works with your preferred frameworks and tools.
 
-WorkflowAI is pro-ecosystem and pro-integration. We encourage you to build with the frameworks, platforms, and services that best fit your requirements, and we work to [enable seamless integration with your existing tech stack](/docs/quickstarts#integrations).
+WorkflowAI is pro-ecosystem and pro-integration. We encourage you to build with the frameworks, platforms, and services that best fit your requirements, and we work to [enable seamless integration with your existing tech stack](/quickstarts#integrations).
 
 ## WorkflowAI is designed for Agent Experience (AX)
 
@@ -28,7 +28,7 @@ This means your favorite agents - ChatGPT, Claude, Cursor, or any AI assistant -
 
 Today's best AI models don't come from just one provider. Leading companies like AI Cursor use models from Anthropic, Google, and OpenAI strategically, choosing the right model for each specific task. WorkflowAI enables this same flexibility without vendor lock-in.
 
-We provide access to [cutting-edge models from all major providers](/docs/inference/models) through a single API that just works everywhere. Your team can **choose the best model for each task** without rewriting application code, **switch between providers instantly** as new models are released, and **avoid vendor lock-in** that limits your technology choices. This lets you **focus on building agents** instead of managing multiple API integrations.
+We provide access to [cutting-edge models from all major providers](/inference/models) through a single API that just works everywhere. Your team can **choose the best model for each task** without rewriting application code, **switch between providers instantly** as new models are released, and **avoid vendor lock-in** that limits your technology choices. This lets you **focus on building agents** instead of managing multiple API integrations.
 
 While large engineering teams like [Harvey AI](https://www.harvey.ai/blog/resilient-ai-infrastructure) can build their own AI infrastructure, we believe most teams benefit from using a proven open-source solution that handles this complexity for them.
 
@@ -50,7 +50,7 @@ If you need to move away, you won't have to tear apart your application to remov
 
 Building reliable AI infrastructure requires solving complex challenges: multi-region deployments for high availability, real-time monitoring across dozens of models, scaling observability systems for high-volume workloads, managing failover between providers, and ensuring regular maintenance and backups.
 
-As a fully managed platform, WorkflowAI handles these operational burdens so you can focus on what matters most: building exceptional AI agents. We manage your **inference infrastructure** with [multi-region redundancy](/docs/inference/reliability) and 24/7 monitoring, provide **[observability](/docs/observability)** that scales with your application volume, ensure **[provider failover](/docs/inference/reliability)** and manage rate limits efficiently for maximum reliability, manage [tools](/docs/agents/tools) for your agents, deliver **performance optimization** across different model types and providers, including features like [structured outputs](/docs/inference/structured-outputs) and [caching](/docs/inference/caching), and handle regular **maintenance and backups** to keep your systems running smoothly.
+As a fully managed platform, WorkflowAI handles these operational burdens so you can focus on what matters most: building exceptional AI agents. We manage your **inference infrastructure** with [multi-region redundancy](/inference/reliability) and 24/7 monitoring, provide **[observability](/observability)** that scales with your application volume, ensure **[provider failover](/inference/reliability)** and manage rate limits efficiently for maximum reliability, manage [tools](/agents/tools) for your agents, deliver **performance optimization** across different model types and providers, including features like [structured outputs](/inference/structured-outputs) and [caching](/inference/caching), and handle regular **maintenance and backups** to keep your systems running smoothly.
 
 This approach allows your team to concentrate on developing AI applications rather than managing the underlying infrastructure complexity.
 
@@ -62,10 +62,10 @@ This approach allows your team to concentrate on developing AI applications rath
 
 Most customers actually save money because they can quickly identify and switch to cheaper models that meet their performance (quality, latency) requirements.
 
-Read more about [our pricing and business model](/docs/pricing).
+Read more about [our pricing and business model](/pricing).
 
 <Card
   title="Ready to get started?"
   description="Get started with WorkflowAI in minutes"
-  href="/docs/quickstarts"
+  href="/quickstarts"
 />


### PR DESCRIPTION
## Summary

Updates all internal documentation links in  to remove the  prefix, changing from  format to  format.

## Changes Made

- **27 files updated** with clean 1:1 link replacements
- Updated links across all documentation sections:
  - Quickstarts (Python, JS/TS, Instructor, no-code)
  - Inference (models, cost, structured outputs)
  - Observability (runs, conversations, insights, etc.)
  - Deployments
  - Reference documentation
  - Use cases and evaluations
  - Shared components (features-cards.mdx)

## Examples

- ✅  → 
- ✅  →   
- ✅  → 
- ✅ External links preserved:  (unchanged)

## Testing

All changes are purely link updates with no content modifications. The documentation structure and content remain identical - only the internal link format has been standardized.

## Related

Part of documentation link standardization effort to improve navigation consistency.