### PR TITLE
[tentative] add link to stripe fulfillment policy on landing page

### DIFF
--- a/client/src/app/landing/LandingPage.tsx
+++ b/client/src/app/landing/LandingPage.tsx
@@ -155,6 +155,18 @@ export function LandingPage() {
           className='sm:mt-20 mt-14 sm:mb-20 mb-14'
           routeForSignUp={routeForSignUp}
         />
+
+        {/* Simple footer with Stripe Fulfillment Policy link */}
+        <div className='flex justify-center w-full py-4 px-4 border-t border-gray-100'>
+          <a
+            href='https://docs.workflowai.com/workflowai-cloud/pricing#stripe-fulfillment-policy'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-sm text-gray-600 underline hover:text-gray-800 transition-colors'
+          >
+            Stripe Fulfillment Policy
+          </a>
+        </div>
       </LandingPageContainer>
     </div>
   );


### PR DESCRIPTION
Note: unsure if this is needed, but ChatGPT strongly recommends linking the fulfillment policy on the landing page. This isn't any super pretty UI, just asked Cursor to add a basic footer with the link.

Ref: https://linear.app/workflowai/issue/WOR-5058/stripe-fulfillment-policy

https://github.com/user-attachments/assets/f15abd67-6bce-48b4-b38b-a1dacb4b952f

