### PR TITLE
retry_run tool

### DIFF
--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -683,7 +683,7 @@ class MCPService:
 
         if original_run_data.version.properties.model == model and not any([messages, response_format, temperature]):
             raise MCPError(
-                f"Modes {model} are the same, and neither messages, response_format, nor temperature are provided. Please retry this tool call with the parameters that differ from the original run.",
+                f"Model {model} is already used in the original run, and neither messages, response_format, nor temperature are provided. Please retry this tool call with the parameters that differ from the original run.",
             )
 
         return await self.create_completion(


### PR DESCRIPTION
Related to [WOR-4993: Investigate repeated quote in GenerateSoapnoteFromTranscript output](https://linear.app/workflowai/issue/WOR-4993/investigate-repeated-quote-in-generatesoapnotefromtranscript-output)

While investigating how to fix the issue above with MCP, I found that Cursor struggles to know when to use `create_completion` with a `orginal_run_id`, e.g

<img width="524" alt="Screenshot 2025-06-25 at 16 41 46" src="https://github.com/user-attachments/assets/daed6fb0-770b-4063-8c07-65d2e319fd96" />

Cursor is stuck regenrating the transcript it got from a previous `fetch_run_details`.

With my update, the behaviour changes. Cursor understands it must call the `retry_run` tool and still struggles to understand that it must pass an updated response format —since this is what it had just fixed in the user code. But thanks to the explicit error, Cursor corrects its tool call. 

<img width="516" alt="Screenshot 2025-06-25 at 17 01 48" src="https://github.com/user-attachments/assets/2d10afba-aa8d-4735-8cc1-aa178d5d260e" />

(sorry, I should have copied the full markdown of the Cursor discussion for clarity. I'll do that next time.)

I'm not 100% sure we need a separate `retry_run` tool, but this is an option we have to make the usage more obvious. 