### PR TITLE
Add additional playground documentation

### DIFF
--- a/docsv2/content/docs/playground/collaboration-tools.mdx
+++ b/docsv2/content/docs/playground/collaboration-tools.mdx
@@ -11,4 +11,23 @@ The playground generates unique URLs for each state, making collaboration effort
 
 ## Code-Free Deployments: Deploy changes seamlessly without code modifications
 
-TODO: add
+### Why use deployments?
+
+- ✅ Update models or prompts without involving your engineering team
+- ✅ Save costs by switching to newer, cheaper models without code changes
+- ✅ Improve output quality by adjusting prompts in real-time based on user feedback
+- ✅ Use different versions across environments (development, staging, production)
+
+### How to deploy?
+
+If you just ran a version in the playground that you want to deploy, you can deploy it directly from there.
+
+1. Find the deploy button (circled arrow icon) in the output column:
+   - Top of the column (next to model name)
+   - Metadata section (below output)
+2. Select your target environment: production, staging, or dev
+3. Click the deploy button
+4. If this is the first time you deploy a version of this agent, you will need to update your code. You can find updated code on the Code page, or ask the MCP to update your code for you [TODO: clarify phrasing/process re: the MCP]
+
+
+For more information on deployments, see the [Deployments](/docsv2/content/docs/deployments/index.mdx) page.


### PR DESCRIPTION
As discovered when investigating https://linear.app/workflowai/issue/WOR-5089/playground-chat-not-aware-of-playground-deployments, our current documentation doesn't mention deployments being available on the playground. 
