### PR TITLE
POC: Add programming_language parameter to search_documentation MCP tool

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -677,8 +677,14 @@ async def search_documentation(
         default=None,
         description="Use page when you know which specific page contains the information you need.",
     ),
+    programming_language: str | None = Field(
+        default=None,
+        description="The programming language to generate code examples for (e.g., 'python', 'typescript', 'javascript', 'go', 'rust', 'java', 'csharp'). This can help provide more relevant documentation with language-specific examples.",
+    ),
 ) -> MCPToolReturn[SearchResponse]:
     service = await get_mcp_service()
+    # TODO: Pass programming_language to service when implementing POC
+    _ = programming_language  # Unused for now
     try:
         return await service.search_documentation(query=query, page=page)
     except MCPError as e:


### PR DESCRIPTION
## Overview

This PR adds a new optional  parameter to the  MCP tool as a **proof of concept (POC)**.

## Purpose

The goal of this POC is to **test whether MCP clients will actually populate the  parameter** when calling the  tool. This will help us understand:

1. **Client Behavior**: Do MCP clients automatically detect and pass their programming language?
2. **Usage Patterns**: How often do developers specify a target programming language for documentation?
3. **Implementation Feasibility**: Is this approach viable for providing language-specific documentation examples?

## Changes Made

- ✅ Added  parameter to  function
- ✅ Added comprehensive Field description with examples (python, typescript, javascript, go, rust, java, csharp)
- ✅ Parameter is currently **unused** in the service layer (POC stage)
- ✅ Added TODO comment for future implementation
- ✅ All linting checks pass (ruff, pyright)

## Parameter Details

```python
programming_language: str | None = Field(
    default=None,
    description="The programming language to generate code examples for (e.g., 'python', 'typescript', 'javascript', 'go', 'rust', 'java', 'csharp'). This can help provide more relevant documentation with language-specific examples.",
)
```

## Next Steps

1. **Deploy this POC** to see if MCP clients populate the parameter
2. **Monitor usage** to understand adoption patterns  
3. **Implement service layer** to actually use the parameter for language-specific documentation
4. **Evaluate results** to decide if this approach should be expanded to other MCP tools

## Testing

- [x] Ruff linting passes
- [x] Pyright type checking passes
- [x] Parameter is properly documented
- [x] Backward compatible (optional parameter)

---

**Note**: This is a POC to gather real-world usage data. The parameter is not yet implemented in the documentation service.