### PR TITLE
Improve foundations documentation and add MCP tool enhancement suggestion

### DIFF
--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -547,6 +547,7 @@ class MCPService:
 
         # Always add foundations page
         # TODO: try to return the foundations page only once, per chat, but might be difficult since `mcp-session-id` is probably not scoped to a chat (for example, on CursorAI, multiple chat tabs can be open at the same time, using (probably) the same `mcp-session-id`)
+        # @guillaume suggested to add a `read_foundations: true, false` parameter to the search_documentation MCP tool
         sections = await documentation_service.get_documentation_by_path(["foundations"])
         query_results.append(
             SearchResponse.QueryResult(

--- a/docsv2/content/docs/foundations.mdx
+++ b/docsv2/content/docs/foundations.mdx
@@ -42,6 +42,17 @@ By default, WorkflowAI saves all LLM completions. Observability is critical for 
 
 Learn more about by reading the [Observability](/observability) section.
 
+### Playground
+
+Playground is accessible via the WorkflowAI web app and allows a human to test a agent with a dedicated UI optimized for:
+- comparing models side-by-side
+- testing different prompts and parameters
+- testing different input
+
+It's a good idea to send a link to the playground to your user after you have implemented a first version of the agent, by using the URL `https://workflowai.com/agents/agent_id/playground`, or when the user wants to compare different models side-by-side.
+
+The playground has a "Send to Cursor" button that allows to send a specific agent version back to Cursor, so that the user can continue the development in Cursor.
+
 ### Deployments
 
 Deployments allow you to update an agent's prompt or model without changing the code. Learn more about deployments by reading the [Deployments](/deployments) section.


### PR DESCRIPTION
## Summary

This PR includes two focused improvements:

### 1. Enhanced Foundations Documentation
- Added comprehensive **Playground** section to 
- Documents how to use the WorkflowAI web app for testing agents
- Explains side-by-side model comparison and prompt testing features  
- Details the 'Send to Cursor' button functionality
- Provides guidance on when to share playground links with users

### 2. Code Documentation Enhancement
- Added comment in  documenting Guillaume's suggestion
- Proposes adding  parameter to  MCP tool
- Would help control when foundations page is included in search results

## Why These Changes Matter

**Playground Documentation:**
- Improves developer experience by clearly explaining playground features
- Helps users understand when and how to use the playground effectively
- Documents the Cursor integration workflow

**MCP Tool Enhancement:**
- Addresses TODO about returning foundations page only once per chat
- Provides path forward for more granular control of documentation search

Both changes improve developer experience and documentation clarity.

## Files Changed
- `docsv2/content/docs/foundations.mdx` - Added Playground section
- `api/api/routers/mcp/_mcp_service.py` - Added enhancement suggestion comment