### PR TITLE
Docs: add steps to deploy from playground

### DIFF
--- a/docsv2/content/docs/deployments/index.mdx
+++ b/docsv2/content/docs/deployments/index.mdx
@@ -214,7 +214,7 @@ Additionally, if you're using the Playground to run your agent, you can deploy a
 
 1. Select the **Deploy** button (circled arrow icon) in the output column:
    - Top of the column (next to model name)
-   - Metadata section (below output)
+   - Info section (below output)
 2. Select the environment to deploy to from the options on the screen: `development`, `staging`, or `production`
 3. If this is the first time you deploy a version of this agent, you will need to update your code. This can be done in two ways:
     - **(Recommended)** Use the WorkflowAI MCP in Cursor to automatically update your code to reflect the deployment. 

--- a/docsv2/content/docs/deployments/index.mdx
+++ b/docsv2/content/docs/deployments/index.mdx
@@ -210,6 +210,18 @@ The deployment will be associated with a schema number that defines:
 
 You can view all schemas in the **Schemas** section of the WorkflowAI dashboard.
 
+Additionally, if you're using the Playground to run your agent, you can deploy a version from the Playground directly:.
+
+1. Select the **Deploy** button (circled arrow icon) in the output column:
+   - Top of the column (next to model name)
+   - Metadata section (below output)
+2. Select the environment to deploy to from the options on the screen: `development`, `staging`, or `production`
+3. If this is the first time you deploy a version of this agent, you will need to update your code. This can be done in two ways:
+    - **(Recommended)** Use the WorkflowAI MCP in Cursor to automatically update your code to reflect the deployment. 
+    - Manually update your code by navigating to the Code page and copying the generated code. 
+
+TODO: add a video of this process
+
 ### Using the API
 
 TODO: @guillaume


### PR DESCRIPTION
Ref: https://linear.app/workflowai/issue/WOR-5089/playground-chat-not-aware-of-playground-deployments#comment-99716eb2

Keeping the video addition a TODO until closer to the release, so that the video is filmed on the final version of the proxy playground. 