### PR TITLE
Set temperature=0.0 for search_documentation_agent

### DIFF
--- a/api/core/agents/search_documentation_agent.py
+++ b/api/core/agents/search_documentation_agent.py
@@ -122,6 +122,7 @@ Given a search query and all available documentation sections, you must:
         metadata={
             "agent_id": "search-documentation-agent",
         },
+        temperature=0.0,
     )
 
     if completion.choices[0].message.content:


### PR DESCRIPTION
This PR changes the temperature setting for the search_documentation_agent from the default value (1.0) to 0.0 for more deterministic and consistent results.

Changes:
- Modified api/core/agents/search_documentation_agent.py
- Added temperature=0.0 parameter to the completion call
- Changed from default temperature of 1.0 to 0.0

Rationale:
- More deterministic results: Temperature 0.0 provides more consistent documentation section selection
- Better for MCP clients: Improves reliability for MCP clients like Cursor IDE
- Reduced randomness: Documentation search is a precision task, lower temperature is more appropriate

Testing:
- Code quality checks passed: ruff check passed
- Unit tests passing for search_documentation_agent functionality
- No breaking changes: This is an internal parameter change