### PR TITLE
Review search_runs operators: Remove 'is empty' and 'is not empty'

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -337,8 +337,6 @@ async def search_runs(
     - "is not" - not equal to
     - "contains" - string contains
     - "does not contain" - string does not contain
-    - "is empty" - field has no value
-    - "is not empty" - field has a value
 
     **Number fields:**
     - "is" - exact match
@@ -347,8 +345,6 @@ async def search_runs(
     - "greater than or equal to" - value >= X
     - "less than" - value < X
     - "less than or equal to" - value <= X
-    - "is empty" - field has no value
-    - "is not empty" - field has a value
 
     **Date fields:**
     - "is before" - date < X

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -333,14 +333,14 @@ async def search_runs(
     Different field types support different operators:
 
     **String fields:**
-    - "is" - exact match
-    - "is not" - not equal to
+    - "is" - exact match (use value "Empty" to check for empty/null fields)
+    - "is not" - not equal to (use value "Empty" to check for non-empty fields)
     - "contains" - string contains
     - "does not contain" - string does not contain
 
     **Number fields:**
-    - "is" - exact match
-    - "is not" - not equal to
+    - "is" - exact match (use value "Empty" to check for empty/null fields)
+    - "is not" - not equal to (use value "Empty" to check for non-empty fields)
     - "greater than" - value > X
     - "greater than or equal to" - value >= X
     - "less than" - value < X
@@ -457,6 +457,25 @@ async def search_runs(
                 "operator": "greater than",
                 "values": [0.95],
                 "type": "number"
+            }
+        ]
+    }
+
+    Example 6 - Search for runs with empty or non-empty fields:
+    {
+        "agent_id": "content-processor",
+        "field_queries": [
+            {
+                "field_name": "input.optional_field",
+                "operator": "is",
+                "values": ["Empty"],
+                "type": "string"
+            },
+            {
+                "field_name": "output.result",
+                "operator": "is not",
+                "values": ["Empty"],
+                "type": "string"
             }
         ]
     }


### PR DESCRIPTION
## Context

The `search_runs` tool documentation currently includes `"is empty"` and `"is not empty"` operators for both String and Number fields. These operators were added by @YBubu in commit d05e6e15c as part of the MVP search runs tool implementation.

## Issue

I'm not sure these operators are actually supported by the search backend. 

## Changes

- Removed `"is empty" - field has no value` from String fields
- Removed `"is not empty" - field has a value` from String fields  
- Removed `"is empty" - field has no value` from Number fields
- Removed `"is not empty" - field has a value` from Number fields

## Request for Review

**Please review the `operators_by_type` section and confirm:**

1. Are `"is empty"` and `"is not empty"` actually supported operators?
2. If not, are there any other operators in the documentation that should be removed?
3. Are there any missing operators that should be added?

The current operators listed are:
- **String**: is, is not, contains, does not contain
- **Number**: is, is not, greater than, greater than or equal to, less than, less than or equal to  
- **Date**: is before, is after
- **Boolean**: is, is not

@YBubu - since you implemented the original search functionality, could you please review?