### PR TITLE
Fix JSON formatting in prompt modal to prevent bracket artifacts

### DIFF
--- a/client/src/components/TaskRunModal/utils.ts
+++ b/client/src/components/TaskRunModal/utils.ts
@@ -25,7 +25,7 @@ export function extractTextFromContent(content: unknown) {
       },
       2
     );
-    text = '```json' + text + '```';
+    text = '```json\n' + text + '\n```';
     orginalText = JSON.stringify(content, null, 2);
   } else {
     text = String(content);


### PR DESCRIPTION
Fixes JSON formatting issue where bracket artifacts appeared in prompt modal. Closes: https://linear.app/workflowai/issue/WOR-3792/bracket-and-backticks-added-at-end-of-some-messages