### PR TITLE
Rename create_completion to test_agent to clarify purpose

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -687,10 +687,10 @@ async def search_documentation(
 
 
 @_mcp.tool()
-async def create_completion(
+async def test_agent(
     # TODO: we should not need the agent id here
     agent_id: str = Field(
-        description="The id of the user's agent. Example: 'agent_id': 'email-filtering-agent' in metadata, or 'email-filtering-agent' in 'model=email-filtering-agent/gpt-4o-latest'.",
+        description="The id of the agent. Example: 'agent_id': 'email-filtering-agent' in metadata, or 'email-filtering-agent' in 'model=email-filtering-agent/gpt-4o-latest'.",
     ),
     # TODO: we should likely split the completion request object
     request: OpenAIProxyChatCompletionRequest = Field(
@@ -698,20 +698,22 @@ async def create_completion(
     ),
     original_run_id: str | None = Field(
         default=None,
-        description="A run ID to repeat. Parameters provided in the request will override the "
-        "parameters in the original completion request",
+        description="Optional run ID to retry/debug a previous run. When provided, the tool will use the original run's configuration (messages, tools, temperature, etc.) as a baseline, then apply any parameters specified in the request to override or modify the behavior. Useful for debugging failed runs or testing variations of successful runs.",
     ),
 ) -> MCPToolReturn[OpenAIProxyChatCompletionResponse]:
-    """Create a completion for an agent.
+    """Test an agent for debugging and development purposes.
 
     <when_to_use>
-    Use create_completion to:
+    Use test_agent to:
     - Test or compare different AI models without local setup
-    - Create a completion for a WorkflowAI agent (new or existing)
-    - Quickly prototype prompts, structured outputs, or templates
     - Debug agent behavior by testing specific inputs
+    - Quickly prototype prompts, structured outputs, or templates
     - Compare model performance (speed, cost, quality)
     - Retry an existing run with different parameters (requires 'original_run_id' to be provided)
+
+    ⚠️ IMPORTANT: This tool is NOT intended for:
+    - Production integrations or applications
+    - Direct API calls from your application code
 
     Supports all OpenAI API features including structured outputs (Pydantic models),
     prompt templates with Jinja2, input variables, and tool calling.


### PR DESCRIPTION
## Problem

Based on feedback from Max, the `create_completion` tool name was causing confusion in the MCP client. MCP client (Cursor) thought they could use it directly in production code for their applications, when it's specifically designed for testing and debugging purposes only.

![CleanShot 2025-07-01 at 00 17 02@2x](https://github.com/user-attachments/assets/942994f6-09b3-4c63-a614-d3ce05b79043)


## Solution

Renamed the function to `test_agent` which makes the testing/debugging purpose immediately clear and prevents confusion about production usage.

## Changes Made

- **Renamed function**: `create_completion` → `test_agent`
- **Improved descriptions**: Updated function and parameter descriptions for clarity
- **Enhanced `original_run_id` parameter**: Much more detailed description explaining when and how to use it for debugging
- **Added clear warnings**: Explicit section about what the tool is NOT intended for
- **Restructured documentation**: Cleaner `when_to_use` section with focused bullet points
- **Clarified agent_id**: Simplified parameter description

## Context

This addresses the confusion where MCP clients might think `create_completion` is suitable for production integrations. The new name `test_agent` makes it obvious this is a testing/debugging tool, not a production API endpoint.

The improved documentation also provides better guidance on proper usage patterns and alternatives for production use cases.