### PR TITLE
Disable deployment confirmation tool in MCP server

### DIFF
--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -498,7 +498,7 @@ async def search_runs(
     )
 
 
-@_mcp.tool()
+# @_mcp.tool()
 async def get_deployment_confirmation_url(
     agent_id: Annotated[
         str,


### PR DESCRIPTION
This PR temporarily disables the `get_deployment_confirmation_url` tool from being exposed via the MCP server by commenting out the `@_mcp.tool()` decorator.

## Changes
- Commented out `@_mcp.tool()` decorator for `get_deployment_confirmation_url` function in `api/api/routers/mcp/mcp_server.py`

## Impact
- The deployment confirmation tool will no longer be available through the MCP interface
- This is a temporary change to disable the tool while maintaining the function code

## Testing
- [ ] Verify MCP server still starts without errors
- [ ] Confirm the tool is not listed in MCP tool discovery