### PR TITLE
Truncate fields above 1000 char long

### DIFF
--- a/api/api/routers/mcp/_mcp_errors.py
+++ b/api/api/routers/mcp/_mcp_errors.py
@@ -2,7 +2,6 @@ import json
 from collections.abc import Callable, Coroutine
 from typing import Any
 
-from api.routers.mcp._mcp_models import MCPToolReturn
 from core.utils.generics import BM
 
 
@@ -22,12 +21,15 @@ class MCPError(Exception):
 async def mcp_wrap(
     coro: Coroutine[Any, Any, BM],
     message: Callable[[BM], str | None] | None = None,
-) -> MCPToolReturn[BM]:
+):
     """Wraps a coroutine to return a MCPToolReturn and handle MCPError"""
+    # TODO: fix circular import
+    from api.routers.mcp._mcp_models import MCPToolReturn
+
     try:
         value = await coro
     except MCPError as e:
-        return MCPToolReturn(
+        return MCPToolReturn[BM](
             success=False,
             error=str(e),
         )

--- a/api/api/routers/mcp/_mcp_models.py
+++ b/api/api/routers/mcp/_mcp_models.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import BaseModel, Field
 
-from api.routers.mcp._mcp_utils import truncate_obj
+from api.routers.mcp._mcp_utils import truncate_field, truncate_obj
 from api.schemas.user_identifier import UserIdentifier
 from api.schemas.version_properties import ShortVersionProperties
 from api.services.models import ModelForTask
@@ -704,10 +704,10 @@ class MCPRun(BaseModel):
                 for m in m.content:
                     if m.file and m.file.data:
                         # No need to pass base64 data
-                        m.file.data = truncate_obj(m.file.data, max_field_length=10)
+                        m.file.data = truncate_field(m.file.data, 10)
 
                     if m.text:
-                        m.text = truncate_obj(m.text, max_field_length=10000)
+                        m.text = truncate_field(m.text, 10000)
 
         agent_input = run.task_input
         if agent_input:
@@ -725,7 +725,7 @@ class MCPRun(BaseModel):
             agent_version=AgentVersion.from_domain(version) if version else AgentVersion.from_domain(run.group),
             status="success" if run.status == "success" else "error",
             agent_input=agent_input,
-            messages=run.messages,
+            messages=messages,
             duration_seconds=run.duration_seconds,
             cost_usd=run.cost_usd,
             created_at=run.created_at,

--- a/api/api/routers/mcp/_mcp_models.py
+++ b/api/api/routers/mcp/_mcp_models.py
@@ -691,11 +691,21 @@ class MCPRun(BaseModel):
         url: str,
     ):
         messages = run.messages
+        # Truncation is really arbitrary for now
+        # We limit:
+        # - the length of the message text content to 10000 characters, ~3000 tokens
+        # - the size of input data to 1000 characters, ~300 tokens. The input is repeated in the messages
+        # - the size of the file data to 10 characters since base64 data is not really interesting and eats tokens fast
+        # TODO: implement better truncation logic
+        # Note that when we actually fetch messages from the database, the files will have a URL
         for m in messages:
             for m in m.content:
                 if m.file and m.file.data:
                     # No need to pass base64 data
                     m.file.data = truncate_obj(m.file.data, max_field_length=10)
+
+                if m.text:
+                    m.text = truncate_obj(m.text, max_field_length=10000)
 
         return cls(
             id=run.id,

--- a/api/api/routers/mcp/_mcp_models.py
+++ b/api/api/routers/mcp/_mcp_models.py
@@ -709,7 +709,7 @@ class MCPRun(BaseModel):
                     if m.text:
                         m.text = truncate_field(m.text, 10000)
 
-        agent_input = run.task_input
+        agent_input = run.task_input or None
         if agent_input:
             agent_input = {k: v for k, v in agent_input.items() if k != "workflowai.messages"}
             if truncate:

--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -180,6 +180,7 @@ class MCPService:
         agent_id: str | None,
         run_id: str | None,
         run_url: str | None,
+        truncate: bool = False,
     ) -> MCPRun:
         """Fetch details of a specific agent run."""
 
@@ -199,6 +200,7 @@ class MCPService:
             data.version,
             data.variant.output_schema.json_schema if data.variant else None,
             self.tenant.app_run_url(agent_id, run_id),
+            truncate=truncate,
         )
 
     async def _get_agent_stats(

--- a/api/api/routers/mcp/_mcp_utils.py
+++ b/api/api/routers/mcp/_mcp_utils.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, cast
 
 from api.routers.mcp._mcp_errors import MCPError
 
@@ -34,3 +35,22 @@ def extract_agent_id_and_run_id(run_url: str) -> tuple[str, str]:
     raise MCPError(
         "Invalid run URL, must be in the format 'https://workflowai.com/workflowai/agents/agent-id/runs/run-id', or you must pass 'agent_id' and 'run_id'",
     )
+
+
+def truncate_field(field: str, max_length: int) -> str:
+    if len(field) > max_length:
+        return f"{field[:max_length]}...Truncated"
+    return field
+
+
+def truncate_obj(obj: Any, max_field_length: int = 1000) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        return truncate_field(obj, max_field_length)
+
+    if isinstance(obj, dict):
+        return {k: truncate_obj(v, max_field_length) for k, v in cast(dict[str, Any], obj).items()}
+    if isinstance(obj, list):
+        return [truncate_obj(v, max_field_length) for v in cast(list[Any], obj)]
+    return obj

--- a/api/api/routers/mcp/_mcp_utils_test.py
+++ b/api/api/routers/mcp/_mcp_utils_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from api.routers.mcp._mcp_utils import extract_agent_id_and_run_id
+from api.routers.mcp._mcp_utils import extract_agent_id_and_run_id, truncate_obj
 
 
 class TestMCPServiceExtractAgentIdAndRunId:
@@ -106,3 +106,32 @@ class TestMCPServiceExtractAgentIdAndRunId:
         agent_id, run_id = extract_agent_id_and_run_id(url)  # pyright: ignore[reportPrivateUsage]
         assert agent_id == expected_agent
         assert run_id == expected_run
+
+
+class TestTruncateObj:
+    def test_truncate_obj(self):
+        obj = {"a": "1234567890"}
+        max_field_length = 5
+        expected = {"a": "12345...Truncated"}
+        assert truncate_obj(obj, max_field_length) == expected
+
+    def test_truncate_obj_list(self):
+        obj = ["1234567890"]
+        max_field_length = 5
+        expected = ["12345...Truncated"]
+        assert truncate_obj(obj, max_field_length) == expected
+
+    def test_truncate_obj_nested(self):
+        obj = {
+            "a": [
+                "1234567890",
+                {"b": "1234567890"},
+            ],
+            "c": "1234567890",
+        }
+        max_field_length = 5
+        expected = {
+            "a": ["12345...Truncated", {"b": "12345...Truncated"}],
+            "c": "12345...Truncated",
+        }
+        assert truncate_obj(obj, max_field_length) == expected

--- a/api/api/routers/mcp/mcp_server.py
+++ b/api/api/routers/mcp/mcp_server.py
@@ -194,6 +194,13 @@ async def fetch_run_details(
         str | None,
         Field(description="The url of the run to fetch details for"),
     ] = None,
+    truncate: Annotated[
+        bool,
+        Field(
+            description="Whether to truncate extra long fields in the run details. "
+            "Set to true if the run details response is too long",
+        ),
+    ] = False,
 ) -> MCPToolReturn[MCPRun]:
     """<when_to_use>
     To investigate a specific run of a WorkflowAI agent for debugging, improvement, or troubleshooting. This is particularly useful for:
@@ -232,7 +239,7 @@ async def fetch_run_details(
     This data structure provides everything needed for debugging, performance analysis, cost tracking, and understanding the complete execution context of your WorkflowAI agent.
     </returns>"""
     service = await get_mcp_service()
-    return await mcp_wrap(service.fetch_run_details(agent_id, run_id, run_url))
+    return await mcp_wrap(service.fetch_run_details(agent_id, run_id, run_url, truncate=truncate))
 
 
 @_mcp.tool()
@@ -260,6 +267,8 @@ async def get_agent_versions(
     </when_to_use>
     <returns>
     Returns the details of one or more versions of a WorkflowAI agent.
+    Run details are truncated when searching. If you need the full input or messages data, use the
+    `fetch_run_details` tool.
     </returns>"""
     # TODO: remind the agent what an AgentVersion is ?
     service = await get_mcp_service()


### PR DESCRIPTION
Quick potential fix for https://linear.app/workflowai/issue/WOR-5117/mcp-search-runs-tool-fails-with-single-item-exceeds-token-limit-error

- limit message base64 data at 10 characters since it is not really interesting for LLMs
- limit input values to 1000 characters
- limit message text content to 10000 characters

Size is arbitrary for now. Just to test what is actually helpful for the LLM

Truncated text gets the `...Truncated` suffix

For now, there is no mention of a way to "fetch the entire payload".