### PR TITLE
Increase MCP token limit from 20k to 22.5k (90% of Claude's limit)

### DIFF
--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -64,8 +64,10 @@ _logger = logging.getLogger(__name__)
 
 
 # Claude Code only support 25k tokens, for example.
-# Overall it's a good practice to limit the tool return tokens to avoid overflowing the coding agents context.
-MAX_TOOL_RETURN_TOKENS = 20000
+# (see: `MAX_MCP_OUTPUT_TOKENS` in https://docs.anthropic.com/en/docs/claude-code/settings#global-configuration)
+# Set to 90% of 25k tokens to maximize data returned while avoiding context overflow.
+# Returning more data is usually valuable for the AI agent.
+MAX_TOOL_RETURN_TOKENS = 22500
 
 
 class MCPService:

--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -66,6 +66,7 @@ _logger = logging.getLogger(__name__)
 # Claude Code only support 25k tokens, for example.
 # (see: `MAX_MCP_OUTPUT_TOKENS` in https://docs.anthropic.com/en/docs/claude-code/settings#global-configuration)
 # Set to 90% of 25k tokens to maximize data returned while avoiding context overflow.
+# We leave 10% buffer because the tokenizer for Claude might be different than the GPT-4o tokenizer used here.
 # Returning more data is usually valuable for the AI agent.
 MAX_TOOL_RETURN_TOKENS = 22500
 

--- a/docsv2/content/docs/partials/openai-csharp-code.mdx
+++ b/docsv2/content/docs/partials/openai-csharp-code.mdx
@@ -17,6 +17,7 @@ OpenAIClient client = new OpenAIClient(
 
 ChatClient chatClient = client.GetChatClient("model-name");
 ChatCompletion completion = chatClient.CompleteChat(
-    // your existing code
+    // TODO: add structured output, metadata, input variables
+    // response cost, latency
 );
 ``` 

--- a/docsv2/content/docs/partials/openai-go-code.mdx
+++ b/docsv2/content/docs/partials/openai-go-code.mdx
@@ -15,7 +15,7 @@ import (
 func main() {
 	// setup WorkflowAI client
 	client := openai.NewClient(
-		option.WithBaseURL("https://run.workflowai.com/v1"), // [!code highlight]
+		option.WithBaseURL("https://run.workflowai.com/v1/"), // [!code highlight]
 		option.WithAPIKey("wai-***"), // use create_api_key MCP tool // [!code highlight]
 	)
 
@@ -26,4 +26,6 @@ func main() {
 		},
 	)
 }
-``` 
+```
+
+**Important:** The `WithBaseURL` parameter must include a trailing slash (`/`) at the end of the URL. Without it, the `v1` path segment gets removed, causing API calls to fail. This is a known limitation of the OpenAI Go SDK.

--- a/docsv2/content/docs/partials/openai-go-code.mdx
+++ b/docsv2/content/docs/partials/openai-go-code.mdx
@@ -15,7 +15,7 @@ import (
 func main() {
 	// setup WorkflowAI client
 	client := openai.NewClient(
-		option.WithBaseURL("https://run.workflowai.com/v1/"), // [!code highlight]
+		option.WithBaseURL("https://run.workflowai.com/v1"), // [!code highlight]
 		option.WithAPIKey("wai-***"), // use create_api_key MCP tool // [!code highlight]
 	)
 
@@ -28,4 +28,4 @@ func main() {
 }
 ```
 
-**Important:** The `WithBaseURL` parameter must include a trailing slash (`/`) at the end of the URL. Without it, the `v1` path segment gets removed, causing API calls to fail. This is a known limitation of the OpenAI Go SDK.
+**Important:** Make sure to use the latest version of the OpenAI Go SDK for the best compatibility and performance.

--- a/docsv2/content/docs/partials/openai-go-code.mdx
+++ b/docsv2/content/docs/partials/openai-go-code.mdx
@@ -19,12 +19,33 @@ func main() {
 		option.WithAPIKey("wai-***"), // use create_api_key MCP tool // [!code highlight]
 	)
 
-	chatCompletion, err := client.Chat.Completions.New(
-		context.TODO(),
-		openai.ChatCompletionNewParams{
-			// your existing code
+	params := openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("gemini-2.5-flash"), // TODO: to be tested, not 100% sure this format works
+		Messages: []openai.ChatCompletionMessage{
+			{Role: "user", Content: "You are a helpful assistant that analyzes emails and provides a summary of the content. Analyze the following email: {{email}}"},
 		},
-	)
+		// TODO: add structured outputs
+		responseFormat: ...
+	}
+
+	extraFields := map[string]interface{}{
+		// input variables
+		"input": map[string]interface{}{
+			"email": "Dear team, please review the quarterly report...",
+		},
+		// I've tried using Metadata: from OpenAI Go SDK, but it didn't work.
+		"metadata": map[string]interface{}{
+			"agent_id":   "email-analyzer",
+			"user_email": "user@example.com",
+		},
+	}
+
+	params.SetExtraFields(extraFields)
+
+	chatCompletion, err := client.Chat.Completions.New(context.TODO(), params)
+
+	// access response, cost, latency.
+	// ..
 }
 ```
 

--- a/docsv2/content/docs/partials/openai-java-code.mdx
+++ b/docsv2/content/docs/partials/openai-java-code.mdx
@@ -24,3 +24,6 @@ public class WorkflowAIExample {
         );
     }
 } 
+
+// TODO: add structured output, metadata, input variables
+// response cost, latency

--- a/docsv2/content/docs/partials/openai-javascript-code.mdx
+++ b/docsv2/content/docs/partials/openai-javascript-code.mdx
@@ -13,6 +13,7 @@ const client = new OpenAI({
 });
 
 client.chat.completions.create({
-  // your existing code
+  // TODO: add structured output, metadata, input variables
+  // response cost, latency
 })
 ``` 

--- a/docsv2/content/docs/partials/openai-python-code.mdx
+++ b/docsv2/content/docs/partials/openai-python-code.mdx
@@ -13,6 +13,8 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-  # your existing code
+  # TODO:
+  # add structured output, metadata, input variables
+  # response cost, latency
 )
 ``` 

--- a/docsv2/content/docs/partials/openai-ruby-code.mdx
+++ b/docsv2/content/docs/partials/openai-ruby-code.mdx
@@ -13,6 +13,7 @@ client = OpenAI::Client.new(
 )
 
 response = client.chat.completions.create(
-  # your existing code
+  # add structured output, metadata, input variables
+  # response cost, latency
 )
 ``` 

--- a/docsv2/content/docs/partials/openai-rust-code.mdx
+++ b/docsv2/content/docs/partials/openai-rust-code.mdx
@@ -25,7 +25,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "content": "Hello, how are you?"
                 }
             ]
-            // your existing parameters
+            // TODO: add structured output, metadata, input variables
+            // response cost, latency
+            // ...
         }))
         .send()
         .await?;

--- a/docsv2/content/docs/partials/openai-typescript-code.mdx
+++ b/docsv2/content/docs/partials/openai-typescript-code.mdx
@@ -13,6 +13,7 @@ const client: OpenAI = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  // your existing code
+  // TODO: add structured output, metadata, input variables
+  // response cost, latency
 });
 ``` 


### PR DESCRIPTION
## Summary

Increases the MCP response token limit from 20,000 to 22,500 tokens (90% of Claude's 25k limit).

## Changes

- Changed `MAX_TOOL_RETURN_TOKENS` from 20,000 to 22,500
- Updated comments to reflect new reasoning

## Justification

- Returning more data is usually valuable for AI agents in practice
- 90% limit maximizes data while avoiding context overflow
- 10% buffer accounts for potential tokenizer differences between GPT-4o (used for estimation) and Claude's actual tokenizer

## Impact

This change affects all MCP tool responses that use pagination:
- `list_models()`
- `list_agents()` 
- `get_agent_version()`
- `list_agent_versions()`
- `search_runs()`

Users will receive more comprehensive data in MCP responses while staying within safe token limits.