### PR TITLE
Increase MCP token limit from 20k to 22.5k (90% of Claude's limit)

### DIFF
--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -64,8 +64,10 @@ _logger = logging.getLogger(__name__)
 
 
 # Claude Code only support 25k tokens, for example.
-# Overall it's a good practice to limit the tool return tokens to avoid overflowing the coding agents context.
-MAX_TOOL_RETURN_TOKENS = 20000
+# Set to 90% of 25k tokens to maximize data returned while avoiding context overflow.
+# We leave 10% buffer because the tokenizer for Claude might be different than the GPT-4o tokenizer used here.
+# Returning more data is usually valuable for the AI agent.
+MAX_TOOL_RETURN_TOKENS = 22500
 
 
 class MCPService:

--- a/api/api/routers/mcp/_mcp_service.py
+++ b/api/api/routers/mcp/_mcp_service.py
@@ -64,6 +64,7 @@ _logger = logging.getLogger(__name__)
 
 
 # Claude Code only support 25k tokens, for example.
+# (see: `MAX_MCP_OUTPUT_TOKENS` in https://docs.anthropic.com/en/docs/claude-code/settings#global-configuration)
 # Set to 90% of 25k tokens to maximize data returned while avoiding context overflow.
 # We leave 10% buffer because the tokenizer for Claude might be different than the GPT-4o tokenizer used here.
 # Returning more data is usually valuable for the AI agent.


### PR DESCRIPTION
## Summary

Increases the MCP response token limit from 20,000 to 22,500 tokens (90% of Claude's 25k limit).

## Changes

- Changed `MAX_TOOL_RETURN_TOKENS` from 20,000 to 22,500
- Updated comments to reflect new reasoning

## Justification

- Returning more data is usually valuable for AI agents in practice
- 90% limit maximizes data while avoiding context overflow  
- 10% buffer accounts for potential tokenizer differences between GPT-4o (used for estimation) and Claude's actual tokenizer

## Impact

This change affects all MCP tool responses that use pagination:
- `list_models()`
- `list_agents()`
- `get_agent_version()`
- `list_agent_versions()`
- `search_runs()`

Users will receive more comprehensive data in MCP responses while staying within safe token limits.