### PR TITLE
Fix MCP installation command to include -s user parameter

### DIFF
--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -61,7 +61,7 @@ Cursor UI should now look like this (note the green indicator and the number of 
 2. Type the following to install:
 
 ```bash
-claude mcp add workflowai https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
+claude mcp add workflowai -s user https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
 ```
 
 Replace `YOUR_API_KEY_HERE` with your WorkflowAI API key.

--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -61,7 +61,7 @@ Cursor UI should now look like this (note the green indicator and the number of 
 2. Type the following to install:
 
 ```bash
-claude mcp add workflowai -s user https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
+claude mcp add -s user workflowai https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
 ```
 
 Replace `YOUR_API_KEY_HERE` with your WorkflowAI API key.

--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -66,6 +66,10 @@ claude mcp add workflowai -s user https://api.workflowai.com/mcp/ --transport ht
 
 Replace `YOUR_API_KEY_HERE` with your WorkflowAI API key.
 
+<Callout type="info">
+**Installation Scopes**: The `-s user` flag installs WorkflowAI for your personal use across all projects. For team projects, you can use `-s project` instead to create a shared `.mcp.json` file that can be committed to version control and shared with your team members.
+</Callout>
+
 3. Type the following to verify the server is properly connected:
 
 ```bash

--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -61,7 +61,7 @@ Cursor UI should now look like this (note the green indicator and the number of 
 2. Type the following to install:
 
 ```bash
-claude mcp add -s user workflowai https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
+claude mcp add workflowai -s user https://api.workflowai.com/mcp/ --transport http -H "Authorization: Bearer YOUR_API_KEY_HERE"
 ```
 
 Replace `YOUR_API_KEY_HERE` with your WorkflowAI API key.

--- a/docsv2/content/docs/index.mdx
+++ b/docsv2/content/docs/index.mdx
@@ -67,7 +67,7 @@ claude mcp add workflowai -s user https://api.workflowai.com/mcp/ --transport ht
 Replace `YOUR_API_KEY_HERE` with your WorkflowAI API key.
 
 <Callout type="info">
-**Installation Scopes**: The `-s user` flag installs WorkflowAI for your personal use across all projects. For team projects, you can use `-s project` instead to create a shared `.mcp.json` file that can be committed to version control and shared with your team members.
+**Installation Scopes**: The `-s user` flag installs WorkflowAI for your personal use across all projects. For team projects, you can use `-s project` instead to create a shared `.mcp.json` file that can be committed to version control and shared with your team members. Learn more about MCP scopes in the [Anthropic documentation](https://docs.anthropic.com/en/docs/claude-code/mcp#user-scope).
 </Callout>
 
 3. Type the following to verify the server is properly connected:


### PR DESCRIPTION
This PR fixes the MCP installation command in the documentation by adding the required `-s user` parameter.

## What Changed
- Added `-s user` parameter to the `claude mcp add` command in the getting started documentation

## Why This Change Matters
According to the [Anthropic MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp#user-scope), MCP servers can be configured at three different scope levels:

- **Local scope** (default): Available only in the current project
- **Project scope**: Shared with everyone in the project via `.mcp.json` file  
- **User scope**: Available across all projects on your machine

By adding `-s user`, we're specifying that the WorkflowAI MCP server should be installed at the **user scope** level. This means:

✅ **Cross-project accessibility**: The WorkflowAI MCP server will be available across all projects on the user's machine
✅ **Personal utility**: Perfect for a general-purpose AI workflow tool that users would want to access from any project
✅ **Persistent availability**: Users won't need to reconfigure the MCP server for each new project

Without this parameter, the MCP server would only be available in the current project directory, which is not the expected behavior for a general-purpose tool like WorkflowAI.

## Reference
- [Anthropic MCP Documentation - User Scope](https://docs.anthropic.com/en/docs/claude-code/mcp#user-scope) 
